### PR TITLE
docs(best-practices): add cloud provider CIDR limits section

### DIFF
--- a/packages/docs/src/content/docs/guides/best-practices.mdx
+++ b/packages/docs/src/content/docs/guides/best-practices.mdx
@@ -108,6 +108,20 @@ Cloud providers reserve IPs in each subnet:
 | Azure | 5 | 251 |
 | GCP | 4 | 252 |
 
+### Respect Cloud Provider CIDR Limits
+
+Each cloud provider has specific constraints on VPC/VNet and subnet sizes:
+
+| Provider | VPC/VNet Range | Subnet Range | Min Subnet Size |
+|----------|----------------|--------------|-----------------|
+| AWS | `/16` to `/28` | `/16` to `/28` | `/28` (11 usable) |
+| Azure | `/8` to `/29` | `/8` to `/29` | `/29` (3 usable) |
+| GCP | `/8` to `/29` | `/8` to `/29` | `/29` (4 usable) |
+
+<Aside type="caution" title="AWS is Most Restrictive">
+AWS doesn't allow VPCs larger than `/16`. If you need more than 65,536 addresses in a single VPC, you must use secondary CIDR blocks or multiple VPCs.
+</Aside>
+
 ### Example Subnet Type Configuration
 
 ```json


### PR DESCRIPTION
## Summary

Adds documentation for cloud provider-specific VPC/VNet and subnet size constraints to the Best Practices guide.

## Changes

Added a new section "Respect Cloud Provider CIDR Limits" with:

| Provider | VPC/VNet Range | Subnet Range | Min Subnet Size |
|----------|----------------|--------------|-----------------|
| AWS | `/16` to `/28` | `/16` to `/28` | `/28` (11 usable) |
| Azure | `/8` to `/29` | `/8` to `/29` | `/29` (3 usable) |
| GCP | `/8` to `/29` | `/8` to `/29` | `/29` (4 usable) |

Also includes a caution note about AWS being the most restrictive provider, as VPCs cannot exceed `/16` without secondary CIDR blocks.

## Why

The existing Best Practices doc covered cloud provider IP reservations but didn't document the CIDR range constraints. This information helps users avoid configuration errors when designing their network architecture.