### PR TITLE
docs: improve cloud provider CIDR limits accuracy

### DIFF
--- a/packages/docs/src/content/docs/cidr-primer.mdx
+++ b/packages/docs/src/content/docs/cidr-primer.mdx
@@ -37,14 +37,14 @@ Learn the fundamentals of CIDR notation and IP subnetting for designing cloud ne
 
 ### Cloud Provider Reserved IPs
 
-| Provider | Reserved per Subnet | Usable in /24 |
-|----------|---------------------|---------------|
-| AWS | 5 | 251 |
-| Azure | 5 | 251 |
-| GCP | 4 | 252 |
+| Provider | Reserved | What's Reserved | Usable in /24 |
+|----------|----------|-----------------|---------------|
+| AWS | 5 | Network + router + DNS + future + broadcast | 251 |
+| Azure | 5 | Network + gateway + 2×DNS + broadcast | 251 |
+| GCP | 4 | Network + gateway + penultimate + broadcast | 252 |
 
 <Aside type="caution">
-Always account for cloud provider reservations when sizing subnets!
+Always account for cloud provider reservations when sizing subnets! Subnetter calculates standard usable IPs (total - 2), so subtract an additional 2-3 IPs for cloud provider reservations.
 </Aside>
 
 ---
@@ -321,12 +321,12 @@ Subnetter automatically prevents these pitfalls by calculating allocations hiera
 
 ### Azure
 
-- VNets can use CIDR blocks from /8 to /29
-- Subnets must be between /8 and /29
+- VNets can use CIDR blocks from /2 to /29 (practically, /8 to /29 recommended)
+- Subnets must be between /2 and /29
 - First 4 IPs and last IP in each subnet are reserved:
   - Network address (first IP)
-  - Gateway (second IP)
-  - Reserved (third and fourth IPs)
+  - Default gateway (second IP)
+  - Azure DNS mapped IPs (third and fourth IPs)
   - Broadcast address (last IP)
 - Minimum subnet size is /29 (8 addresses, 3 usable)
 

--- a/packages/docs/src/content/docs/guides/best-practices.mdx
+++ b/packages/docs/src/content/docs/guides/best-practices.mdx
@@ -100,26 +100,30 @@ Different workloads have different IP requirements:
 
 ### Account for Cloud Provider Reservations
 
-Cloud providers reserve IPs in each subnet:
+Cloud providers reserve IPs in each subnet beyond the standard network and broadcast addresses:
 
-| Provider | Reserved IPs | Usable in /24 |
-|----------|--------------|---------------|
-| AWS | 5 | 251 |
-| Azure | 5 | 251 |
-| GCP | 4 | 252 |
+| Provider | Reserved IPs | What's Reserved | Usable in /24 |
+|----------|--------------|-----------------|---------------|
+| AWS | 5 | Network, VPC router, DNS, future use, broadcast | 251 |
+| Azure | 5 | Network, default gateway, 2× Azure DNS, broadcast | 251 |
+| GCP | 4 | Network, gateway, second-to-last, broadcast | 252 |
+
+<Aside type="note" title="Subnetter's Usable IP Calculation">
+Subnetter calculates usable IPs using the standard formula (total - 2 for network/broadcast). The actual usable IPs in your cloud environment will be slightly lower due to provider-specific reservations shown above. For example, Subnetter reports 254 usable IPs for a `/24`, but AWS/Azure provide 251 and GCP provides 252.
+</Aside>
 
 ### Respect Cloud Provider CIDR Limits
 
 Each cloud provider has specific constraints on VPC/VNet and subnet sizes:
 
-| Provider | VPC/VNet Range | Subnet Range | Min Subnet Size |
-|----------|----------------|--------------|-----------------|
-| AWS | `/16` to `/28` | `/16` to `/28` | `/28` (11 usable) |
-| Azure | `/8` to `/29` | `/8` to `/29` | `/29` (3 usable) |
-| GCP | `/8` to `/29` | `/8` to `/29` | `/29` (4 usable) |
+| Provider | VPC/VNet Range | Subnet Range | Min Subnet | Notes |
+|----------|----------------|--------------|------------|-------|
+| AWS | `/16` to `/28` | `/16` to `/28` | `/28` (11 usable) | Most restrictive; use secondary CIDRs for larger VPCs |
+| Azure | `/2` to `/29` | `/2` to `/29` | `/29` (3 usable) | Very permissive; `/8` recommended as practical max |
+| GCP | `/8` to `/29` | `/8` to `/29` | `/29` (4 usable) | Global VPC spans all regions |
 
-<Aside type="caution" title="AWS is Most Restrictive">
-AWS doesn't allow VPCs larger than `/16`. If you need more than 65,536 addresses in a single VPC, you must use secondary CIDR blocks or multiple VPCs.
+<Aside type="caution" title="AWS VPC Size Limit">
+AWS doesn't allow VPCs larger than `/16` (65,536 addresses). If you need more space, you must add secondary CIDR blocks (up to 5 by default, 50 max) or use multiple VPCs. Plan accordingly when designing multi-region architectures.
 </Aside>
 
 ### Example Subnet Type Configuration


### PR DESCRIPTION
## Summary

Improves the accuracy and clarity of cloud provider CIDR documentation based on verification against official sources.

## Changes

### Best Practices Guide

| Before | After |
|--------|-------|
| Simple reserved IP counts | Added 'What's Reserved' column explaining each provider's specific reservations |
| No mention of Subnetter's calculation | Added note clarifying Subnetter uses standard formula (total-2) vs cloud-specific |
| Azure: `/8` to `/29` | Azure: `/2` to `/29` (with `/8` practical recommendation) |
| Basic table | Added 'Notes' column with provider-specific guidance |
| AWS secondary CIDRs: mentioned | AWS secondary CIDRs: 5 default, 50 max upon request |

### CIDR Primer

- Added 'What's Reserved' column with specific reservation purposes
- Updated caution aside to explain Subnetter's calculation difference
- Corrected Azure VNet range and clarified DNS reservation purpose

## Why This Matters

Users need to understand:
1. **Subnetter's output differs from cloud reality** - The tool reports 254 usable IPs for a `/24`, but AWS/Azure provide 251 and GCP provides 252
2. **Azure is more permissive than documented** - VNets can be as large as `/2`, not just `/8`
3. **What each provider reserves** - Helps with debugging and capacity planning

## Sources

- AWS: [VPC CIDR blocks documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-cidr-blocks.html)
- Azure: [Virtual Network FAQ](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-faq)