### PR TITLE
docs(netbox): add comprehensive TSDoc documentation

### DIFF
--- a/packages/netbox/src/client/types.ts
+++ b/packages/netbox/src/client/types.ts
@@ -1,6 +1,27 @@
 /**
- * NetBox API type definitions
- * Based on NetBox REST API v4.x
+ * @module client/types
+ * @description NetBox API type definitions for REST API v4.x.
+ *
+ * Provides TypeScript interfaces for all NetBox objects used by Subnetter,
+ * including IPAM (prefixes, aggregates, roles), DCIM (sites, locations),
+ * Tenancy (tenants), and Extras (tags).
+ *
+ * ## Type Conventions
+ *
+ * - **Read Types**: Full objects returned from API (e.g., `Prefix`, `Site`)
+ * - **Writable Types**: Create/update request bodies (e.g., `PrefixWritable`)
+ * - **Nested Types**: Embedded references (e.g., `NestedRef`, `NestedTag`)
+ * - **List Params**: Query parameters for list endpoints (e.g., `PrefixListParams`)
+ *
+ * ## NetBox 4.x Changes
+ *
+ * Key changes from NetBox 3.x:
+ * - Prefixes use `scope_type` and `scope_id` instead of `site` field
+ * - New `scope` nested reference in prefix responses
+ *
+ * @see {@link https://docs.netbox.dev/en/stable/models/ | NetBox Data Model}
+ *
+ * @packageDocumentation
  */
 
 import { z } from 'zod';
@@ -9,32 +30,93 @@ import { z } from 'zod';
 // Common Types
 // ============================================================================
 
-/** Nested object reference (used in API responses) */
+/**
+ * Nested object reference returned in API responses.
+ *
+ * @remarks
+ * Many NetBox objects include references to related objects. These are
+ * returned as nested objects with just the essential fields for display
+ * and linking.
+ *
+ * @example
+ * ```typescript
+ * // A prefix's tenant reference:
+ * {
+ *   id: 1,
+ *   url: 'https://netbox/api/tenancy/tenants/1/',
+ *   display: 'Production',
+ *   name: 'Production',
+ *   slug: 'production'
+ * }
+ * ```
+ */
 export interface NestedRef {
+  /** Unique identifier */
   id: number;
+  /** Full API URL for the object */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** Object name */
   name: string;
+  /** URL-safe slug (optional on some types) */
   slug?: string;
 }
 
-/** Choice field value (status, family, etc.) */
+/**
+ * Choice field value for status, family, and other enumerated fields.
+ *
+ * @typeParam T - The string literal type for valid values
+ *
+ * @example
+ * ```typescript
+ * // Prefix status:
+ * { value: 'active', label: 'Active' }
+ * ```
+ */
 export interface ChoiceValue<T extends string = string> {
+  /** Machine-readable value */
   value: T;
+  /** Human-readable label */
   label: string;
 }
 
-/** Paginated API response */
+/**
+ * Standard paginated response wrapper for list endpoints.
+ *
+ * @typeParam T - The type of objects in the results array
+ *
+ * @example
+ * ```typescript
+ * const response: PaginatedResponse<Prefix> = await client.prefixes.list();
+ * console.log(`Found ${response.count} prefixes`);
+ * for (const prefix of response.results) {
+ *   console.log(prefix.prefix);
+ * }
+ * ```
+ */
 export interface PaginatedResponse<T> {
+  /** Total count of matching objects */
   count: number;
+  /** URL to next page (null if no more pages) */
   next: string | null;
+  /** URL to previous page (null if first page) */
   previous: string | null;
+  /** Array of objects for this page */
   results: T[];
 }
 
-/** API error response */
+/**
+ * API error response body.
+ *
+ * @remarks
+ * When an API request fails, NetBox returns an error response with
+ * a `detail` field and potentially additional context.
+ */
 export interface ApiError {
+  /** Human-readable error message */
   detail?: string;
+  /** Additional error context (field-specific errors, etc.) */
   [key: string]: unknown;
 }
 
@@ -42,24 +124,72 @@ export interface ApiError {
 // IPAM Types
 // ============================================================================
 
-/** Prefix status values */
+/**
+ * Valid prefix status values.
+ *
+ * @remarks
+ * - `container`: A supernet containing child prefixes
+ * - `active`: Currently in use
+ * - `reserved`: Reserved for future use
+ * - `deprecated`: No longer in use
+ */
 export type PrefixStatus = 'container' | 'active' | 'reserved' | 'deprecated';
 
-/** IP family values */
+/**
+ * IP address family.
+ *
+ * @remarks
+ * Subnetter currently only supports IPv4 (family 4).
+ */
 export type IpFamily = 4 | 6;
 
-/** Prefix scope type (NetBox 4.x) */
+/**
+ * Prefix scope type for NetBox 4.x.
+ *
+ * @remarks
+ * NetBox 4.x replaced the direct `site` relationship with a polymorphic
+ * scope that can reference sites, locations, regions, or site groups.
+ */
 export type PrefixScopeType = 'dcim.site' | 'dcim.location' | 'dcim.region' | 'dcim.sitegroup' | null;
 
-/** NetBox Prefix object */
+/**
+ * NetBox Prefix object representing an IP network allocation.
+ *
+ * @remarks
+ * Prefixes are the core IPAM object. They can be nested hierarchically
+ * (parent/child relationships) and associated with tenants, sites, roles,
+ * and VLANs.
+ *
+ * @example
+ * ```typescript
+ * const prefix: Prefix = {
+ *   id: 1,
+ *   prefix: '10.1.0.0/16',
+ *   status: { value: 'active', label: 'Active' },
+ *   tenant: { id: 1, name: 'Production', ... },
+ *   // ... other fields
+ * };
+ * ```
+ *
+ * @see {@link PrefixWritable} for create/update fields
+ */
 export interface Prefix {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** Display URL for the web UI */
   display_url: string;
+  /** IP address family (4 or 6) */
   family: ChoiceValue<string>;
+  /** CIDR notation (e.g., '10.1.0.0/16') */
   prefix: string;
-  /** @deprecated Use scope instead in NetBox 4.x */
+  /**
+   * Direct site reference (deprecated in NetBox 4.x)
+   * @deprecated Use `scope` instead
+   */
   site: NestedRef | null;
   /** Scope type for the prefix (NetBox 4.x) */
   scope_type: PrefixScopeType;
@@ -67,135 +197,287 @@ export interface Prefix {
   scope_id: number | null;
   /** Scope object reference (NetBox 4.x) */
   scope: NestedRef | null;
+  /** VRF (Virtual Routing and Forwarding) reference */
   vrf: NestedRef | null;
+  /** Tenant (owner) reference */
   tenant: NestedRef | null;
+  /** VLAN reference */
   vlan: NestedRef | null;
+  /** Operational status */
   status: ChoiceValue<PrefixStatus>;
+  /** Functional role reference */
   role: NestedRef | null;
+  /** Whether this is a pool for IP address assignment */
   is_pool: boolean;
+  /** Whether to consider all IPs as utilized */
   mark_utilized: boolean;
+  /** Brief description */
   description: string;
+  /** Detailed comments (Markdown supported) */
   comments: string;
+  /** Applied tags */
   tags: NestedTag[];
+  /** Custom field values */
   custom_fields: Record<string, unknown>;
+  /** Creation timestamp */
   created: string;
+  /** Last update timestamp */
   last_updated: string;
+  /** Number of child prefixes */
   children: number;
+  /** Nesting depth in the prefix hierarchy */
   _depth: number;
 }
 
-/** Create/Update Prefix request */
+/**
+ * Prefix data for create/update operations.
+ *
+ * @remarks
+ * For NetBox 4.x, use `scope_type` and `scope_id` instead of `site`.
+ * Subnetter sets `scope_type: 'dcim.site'` when associating prefixes
+ * with cloud regions (which are mapped to sites).
+ *
+ * @example
+ * ```typescript
+ * const newPrefix: PrefixWritable = {
+ *   prefix: '10.1.0.0/16',
+ *   status: 'reserved',
+ *   scope_type: 'dcim.site',
+ *   scope_id: 1,
+ *   tenant: 1,
+ *   role: 2,
+ *   description: 'Production VPC',
+ * };
+ * ```
+ */
 export interface PrefixWritable {
+  /** CIDR notation (required) */
   prefix: string;
-  /** @deprecated Use scope_type and scope_id instead in NetBox 4.x */
+  /**
+   * Direct site ID (deprecated in NetBox 4.x)
+   * @deprecated Use `scope_type` and `scope_id` instead
+   */
   site?: number | null;
-  /** Scope type for the prefix (NetBox 4.x): 'dcim.site', 'dcim.location', etc. */
+  /** Scope type for the prefix (NetBox 4.x) */
   scope_type?: PrefixScopeType;
   /** Scope object ID (NetBox 4.x) */
   scope_id?: number | null;
+  /** VRF ID */
   vrf?: number | null;
+  /** Tenant ID */
   tenant?: number | null;
+  /** VLAN ID */
   vlan?: number | null;
+  /** Operational status */
   status?: PrefixStatus;
+  /** Role ID */
   role?: number | null;
+  /** Whether this is a pool */
   is_pool?: boolean;
+  /** Whether to mark all IPs utilized */
   mark_utilized?: boolean;
+  /** Brief description */
   description?: string;
+  /** Detailed comments */
   comments?: string;
+  /** Tags to apply */
   tags?: TagWritable[];
+  /** Custom field values */
   custom_fields?: Record<string, unknown>;
 }
 
-/** NetBox Aggregate object */
+/**
+ * NetBox Aggregate representing a top-level IP block.
+ *
+ * @remarks
+ * Aggregates represent the root of the IP addressing hierarchy, typically
+ * RFC 1918 private ranges or public allocations from an RIR.
+ *
+ * @see {@link AggregateWritable} for create/update fields
+ */
 export interface Aggregate {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** IP address family */
   family: ChoiceValue<string>;
+  /** CIDR notation */
   prefix: string;
+  /** Regional Internet Registry */
   rir: NestedRef;
+  /** Tenant reference */
   tenant: NestedRef | null;
+  /** Date when the aggregate was added */
   date_added: string | null;
+  /** Brief description */
   description: string;
+  /** Detailed comments */
   comments: string;
+  /** Applied tags */
   tags: NestedTag[];
+  /** Custom field values */
   custom_fields: Record<string, unknown>;
+  /** Creation timestamp */
   created: string;
+  /** Last update timestamp */
   last_updated: string;
 }
 
-/** Create/Update Aggregate request */
+/**
+ * Aggregate data for create/update operations.
+ *
+ * @example
+ * ```typescript
+ * const aggregate: AggregateWritable = {
+ *   prefix: '10.0.0.0/8',
+ *   rir: 1, // RFC 1918
+ *   description: 'Private network allocation',
+ * };
+ * ```
+ */
 export interface AggregateWritable {
+  /** CIDR notation (required) */
   prefix: string;
+  /** RIR ID (required) */
   rir: number;
+  /** Tenant ID */
   tenant?: number | null;
+  /** Date added */
   date_added?: string | null;
+  /** Brief description */
   description?: string;
+  /** Detailed comments */
   comments?: string;
+  /** Tags to apply */
   tags?: TagWritable[];
+  /** Custom field values */
   custom_fields?: Record<string, unknown>;
 }
 
-/** Aggregate query parameters */
+/**
+ * Query parameters for listing aggregates.
+ */
 export interface AggregateListParams {
+  /** Maximum results per page */
   limit?: number;
+  /** Offset for pagination */
   offset?: number;
+  /** Filter by prefix */
   prefix?: string;
+  /** Filter by RIR ID */
   rir_id?: number;
+  /** Filter by RIR slug */
   rir?: string;
+  /** Filter by tenant ID */
   tenant_id?: number;
+  /** Filter by tag(s) */
   tag?: string | string[];
 }
 
-/** RIR query parameters */
+/**
+ * Query parameters for listing RIRs.
+ */
 export interface RirListParams {
+  /** Maximum results per page */
   limit?: number;
+  /** Offset for pagination */
   offset?: number;
+  /** Filter by name */
   name?: string;
+  /** Filter by slug */
   slug?: string;
+  /** Filter by private flag */
   is_private?: boolean;
 }
 
-/** NetBox Role object (IPAM) */
+/**
+ * NetBox Role for prefix/VLAN classification.
+ *
+ * @remarks
+ * Roles categorize prefixes and VLANs by their function. Common roles
+ * include 'public', 'private', 'management', etc.
+ */
 export interface Role {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** Role name */
   name: string;
+  /** URL-safe slug */
   slug: string;
+  /** Display weight (lower = higher priority) */
   weight: number;
+  /** Brief description */
   description: string;
+  /** Applied tags */
   tags: NestedTag[];
+  /** Custom field values */
   custom_fields: Record<string, unknown>;
+  /** Creation timestamp */
   created: string;
+  /** Last update timestamp */
   last_updated: string;
+  /** Number of prefixes with this role */
   prefix_count: number;
+  /** Number of VLANs with this role */
   vlan_count: number;
 }
 
-/** Create/Update Role request */
+/**
+ * Role data for create/update operations.
+ */
 export interface RoleWritable {
+  /** Role name (required) */
   name: string;
+  /** URL-safe slug (required) */
   slug: string;
+  /** Display weight */
   weight?: number;
+  /** Brief description */
   description?: string;
+  /** Tags to apply */
   tags?: TagWritable[];
+  /** Custom field values */
   custom_fields?: Record<string, unknown>;
 }
 
-/** NetBox RIR object */
+/**
+ * NetBox RIR (Regional Internet Registry).
+ *
+ * @remarks
+ * RIRs are required for creating aggregates. Subnetter creates an
+ * 'RFC 1918' RIR for private address space.
+ */
 export interface Rir {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** RIR name */
   name: string;
+  /** URL-safe slug */
   slug: string;
+  /** Whether this is for private address space */
   is_private: boolean;
+  /** Brief description */
   description: string;
+  /** Applied tags */
   tags: NestedTag[];
+  /** Custom field values */
   custom_fields: Record<string, unknown>;
+  /** Creation timestamp */
   created: string;
+  /** Last update timestamp */
   last_updated: string;
+  /** Number of aggregates */
   aggregate_count: number;
 }
 
@@ -203,168 +485,328 @@ export interface Rir {
 // DCIM Types
 // ============================================================================
 
-/** NetBox Region object (for geographic/provider hierarchy) */
+/**
+ * NetBox Region for geographic hierarchy.
+ *
+ * @remarks
+ * Regions provide geographic organization. Note: Subnetter uses Sites
+ * for cloud regions to allow Site Groups for provider organization.
+ */
 export interface Region {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** Region name */
   name: string;
+  /** URL-safe slug */
   slug: string;
+  /** Parent region reference */
   parent: NestedRef | null;
+  /** Brief description */
   description: string;
+  /** Applied tags */
   tags: NestedTag[];
+  /** Custom field values */
   custom_fields: Record<string, unknown>;
+  /** Creation timestamp */
   created: string;
+  /** Last update timestamp */
   last_updated: string;
+  /** Number of sites in this region */
   site_count: number;
+  /** Nesting depth */
   _depth: number;
 }
 
-/** Create/Update Region request */
+/**
+ * Region data for create/update operations.
+ */
 export interface RegionWritable {
+  /** Region name (required) */
   name: string;
+  /** URL-safe slug (required) */
   slug: string;
+  /** Parent region ID */
   parent?: number | null;
+  /** Brief description */
   description?: string;
+  /** Tags to apply */
   tags?: TagWritable[];
+  /** Custom field values */
   custom_fields?: Record<string, unknown>;
 }
 
-/** Region query parameters */
+/**
+ * Query parameters for listing regions.
+ */
 export interface RegionListParams {
+  /** Maximum results per page */
   limit?: number;
+  /** Offset for pagination */
   offset?: number;
+  /** Filter by name */
   name?: string;
+  /** Filter by slug */
   slug?: string;
+  /** Filter by parent region ID */
   parent_id?: number;
+  /** Filter by tag(s) */
   tag?: string | string[];
 }
 
-/** NetBox Location object (for AZs within sites) */
+/**
+ * NetBox Location for availability zones within sites.
+ *
+ * @remarks
+ * Locations represent sub-divisions within sites. Subnetter maps cloud
+ * availability zones to locations (e.g., 'us-east-1a').
+ */
 export interface Location {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** Location name */
   name: string;
+  /** URL-safe slug */
   slug: string;
+  /** Parent site reference (required) */
   site: NestedRef;
+  /** Parent location reference */
   parent: NestedRef | null;
+  /** Operational status */
   status: ChoiceValue<string>;
+  /** Tenant reference */
   tenant: NestedRef | null;
+  /** Brief description */
   description: string;
+  /** Applied tags */
   tags: NestedTag[];
+  /** Custom field values */
   custom_fields: Record<string, unknown>;
+  /** Creation timestamp */
   created: string;
+  /** Last update timestamp */
   last_updated: string;
+  /** Number of racks */
   rack_count: number;
+  /** Number of devices */
   device_count: number;
+  /** Nesting depth */
   _depth: number;
 }
 
-/** Create/Update Location request */
+/**
+ * Location data for create/update operations.
+ */
 export interface LocationWritable {
+  /** Location name (required) */
   name: string;
+  /** URL-safe slug (required) */
   slug: string;
+  /** Parent site ID (required) */
   site: number;
+  /** Parent location ID */
   parent?: number | null;
+  /** Operational status */
   status?: string;
+  /** Tenant ID */
   tenant?: number | null;
+  /** Brief description */
   description?: string;
+  /** Tags to apply */
   tags?: TagWritable[];
+  /** Custom field values */
   custom_fields?: Record<string, unknown>;
 }
 
-/** Location query parameters */
+/**
+ * Query parameters for listing locations.
+ */
 export interface LocationListParams {
+  /** Maximum results per page */
   limit?: number;
+  /** Offset for pagination */
   offset?: number;
+  /** Filter by name */
   name?: string;
+  /** Filter by slug */
   slug?: string;
+  /** Filter by site ID */
   site_id?: number;
+  /** Filter by site slug */
   site?: string;
+  /** Filter by parent location ID */
   parent_id?: number;
+  /** Filter by tag(s) */
   tag?: string | string[];
 }
 
-/** NetBox SiteGroup object (for functional/logical grouping like cloud providers) */
+/**
+ * NetBox Site Group for functional/logical grouping.
+ *
+ * @remarks
+ * Site groups provide functional organization of sites. Subnetter maps
+ * cloud providers to site groups (e.g., 'AWS', 'Azure', 'GCP').
+ */
 export interface SiteGroup {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** Site group name */
   name: string;
+  /** URL-safe slug */
   slug: string;
+  /** Parent site group reference */
   parent: NestedRef | null;
+  /** Brief description */
   description: string;
+  /** Applied tags */
   tags: NestedTag[];
+  /** Custom field values */
   custom_fields: Record<string, unknown>;
+  /** Creation timestamp */
   created: string;
+  /** Last update timestamp */
   last_updated: string;
+  /** Number of sites in this group */
   site_count: number;
+  /** Nesting depth */
   _depth: number;
 }
 
-/** Create/Update SiteGroup request */
+/**
+ * Site Group data for create/update operations.
+ */
 export interface SiteGroupWritable {
+  /** Site group name (required) */
   name: string;
+  /** URL-safe slug (required) */
   slug: string;
+  /** Parent site group ID */
   parent?: number | null;
+  /** Brief description */
   description?: string;
+  /** Tags to apply */
   tags?: TagWritable[];
+  /** Custom field values */
   custom_fields?: Record<string, unknown>;
 }
 
-/** SiteGroup query parameters */
+/**
+ * Query parameters for listing site groups.
+ */
 export interface SiteGroupListParams {
+  /** Maximum results per page */
   limit?: number;
+  /** Offset for pagination */
   offset?: number;
+  /** Filter by name */
   name?: string;
+  /** Filter by slug */
   slug?: string;
+  /** Filter by parent site group ID */
   parent_id?: number;
+  /** Filter by tag(s) */
   tag?: string | string[];
 }
 
-/** NetBox Site object */
+/**
+ * NetBox Site for physical/logical locations.
+ *
+ * @remarks
+ * Sites represent physical or logical locations. Subnetter maps cloud
+ * regions to sites (e.g., 'us-east-1' becomes a site under the 'AWS'
+ * site group).
+ */
 export interface Site {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** Site name */
   name: string;
+  /** URL-safe slug */
   slug: string;
+  /** Operational status */
   status: ChoiceValue<string>;
+  /** Geographic region reference */
   region: NestedRef | null;
+  /** Site group reference */
   group: NestedRef | null;
+  /** Tenant reference */
   tenant: NestedRef | null;
+  /** Facility name */
   facility: string;
+  /** Time zone */
   time_zone: string | null;
+  /** Brief description */
   description: string;
+  /** Physical address */
   physical_address: string;
+  /** Shipping address */
   shipping_address: string;
+  /** Geographic latitude */
   latitude: number | null;
+  /** Geographic longitude */
   longitude: number | null;
+  /** Detailed comments */
   comments: string;
+  /** Applied tags */
   tags: NestedTag[];
+  /** Custom field values */
   custom_fields: Record<string, unknown>;
+  /** Creation timestamp */
   created: string;
+  /** Last update timestamp */
   last_updated: string;
 }
 
-/** Create/Update Site request */
+/**
+ * Site data for create/update operations.
+ */
 export interface SiteWritable {
+  /** Site name (required) */
   name: string;
+  /** URL-safe slug (required) */
   slug: string;
+  /** Operational status */
   status?: string;
+  /** Geographic region ID */
   region?: number | null;
+  /** Site group ID */
   group?: number | null;
+  /** Tenant ID */
   tenant?: number | null;
+  /** Facility name */
   facility?: string;
+  /** Time zone */
   time_zone?: string | null;
+  /** Brief description */
   description?: string;
+  /** Physical address */
   physical_address?: string;
+  /** Shipping address */
   shipping_address?: string;
+  /** Geographic latitude */
   latitude?: number | null;
+  /** Geographic longitude */
   longitude?: number | null;
+  /** Detailed comments */
   comments?: string;
+  /** Tags to apply */
   tags?: TagWritable[];
+  /** Custom field values */
   custom_fields?: Record<string, unknown>;
 }
 
@@ -372,30 +814,57 @@ export interface SiteWritable {
 // Tenancy Types
 // ============================================================================
 
-/** NetBox Tenant object */
+/**
+ * NetBox Tenant for organizational ownership.
+ *
+ * @remarks
+ * Tenants represent organizational ownership boundaries. Subnetter maps
+ * cloud accounts to tenants.
+ */
 export interface Tenant {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** Tenant name */
   name: string;
+  /** URL-safe slug */
   slug: string;
+  /** Tenant group reference */
   group: NestedRef | null;
+  /** Brief description */
   description: string;
+  /** Detailed comments */
   comments: string;
+  /** Applied tags */
   tags: NestedTag[];
+  /** Custom field values */
   custom_fields: Record<string, unknown>;
+  /** Creation timestamp */
   created: string;
+  /** Last update timestamp */
   last_updated: string;
 }
 
-/** Create/Update Tenant request */
+/**
+ * Tenant data for create/update operations.
+ */
 export interface TenantWritable {
+  /** Tenant name (required) */
   name: string;
+  /** URL-safe slug (required) */
   slug: string;
+  /** Tenant group ID */
   group?: number | null;
+  /** Brief description */
   description?: string;
+  /** Detailed comments */
   comments?: string;
+  /** Tags to apply */
   tags?: TagWritable[];
+  /** Custom field values */
   custom_fields?: Record<string, unknown>;
 }
 
@@ -403,37 +872,69 @@ export interface TenantWritable {
 // Extras Types (Tags)
 // ============================================================================
 
-/** Nested tag reference */
+/**
+ * Nested tag reference in API responses.
+ */
 export interface NestedTag {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** Tag name */
   name: string;
+  /** URL-safe slug */
   slug: string;
+  /** Hex color code (without #) */
   color: string;
 }
 
-/** NetBox Tag object */
+/**
+ * NetBox Tag for object labeling.
+ *
+ * @remarks
+ * Tags provide flexible labeling for any NetBox object. Subnetter uses
+ * a 'subnetter-managed' tag to identify objects it created.
+ */
 export interface Tag {
+  /** Unique identifier */
   id: number;
+  /** Full API URL */
   url: string;
+  /** Human-readable display string */
   display: string;
+  /** Tag name */
   name: string;
+  /** URL-safe slug */
   slug: string;
+  /** Hex color code (without #) */
   color: string;
+  /** Brief description */
   description: string;
+  /** Object types this tag can be applied to */
   object_types: string[];
+  /** Number of objects with this tag */
   tagged_items: number;
+  /** Creation timestamp */
   created: string;
+  /** Last update timestamp */
   last_updated: string;
 }
 
-/** Create/Update Tag request */
+/**
+ * Tag data for create/update operations.
+ */
 export interface TagWritable {
+  /** Tag name (required) */
   name: string;
+  /** URL-safe slug (required) */
   slug: string;
+  /** Hex color code (without #, e.g., 'ff0000') */
   color?: string;
+  /** Brief description */
   description?: string;
+  /** Object types this tag can be applied to */
   object_types?: string[];
 }
 
@@ -441,9 +942,20 @@ export interface TagWritable {
 // Client Configuration
 // ============================================================================
 
-/** NetBox client configuration */
+/**
+ * NetBox client configuration options.
+ *
+ * @example
+ * ```typescript
+ * const config: NetBoxConfig = {
+ *   url: 'https://netbox.example.com',
+ *   token: process.env.NETBOX_TOKEN!,
+ *   timeout: 60000, // 60 seconds
+ * };
+ * ```
+ */
 export interface NetBoxConfig {
-  /** NetBox base URL (e.g., https://netbox.example.com) */
+  /** NetBox base URL (e.g., 'https://netbox.example.com') */
   url: string;
   /** API token for authentication */
   token: string;
@@ -453,7 +965,13 @@ export interface NetBoxConfig {
   verifySsl?: boolean;
 }
 
-/** Zod schema for NetBox configuration validation */
+/**
+ * Zod schema for NetBox configuration validation.
+ *
+ * @remarks
+ * Used internally by NetBoxClient to validate configuration before
+ * creating the HTTP client.
+ */
 export const NetBoxConfigSchema = z.object({
   url: z.string().url('Invalid NetBox URL'),
   token: z.string().min(1, 'API token is required'),
@@ -465,56 +983,96 @@ export const NetBoxConfigSchema = z.object({
 // Query Parameters
 // ============================================================================
 
-/** Common query parameters for list endpoints */
+/**
+ * Common query parameters for list endpoints.
+ */
 export interface ListParams {
+  /** Maximum results per page */
   limit?: number;
+  /** Offset for pagination */
   offset?: number;
+  /** Field to order by (prefix with - for descending) */
   ordering?: string;
+  /** Full-text search query */
   q?: string;
 }
 
-/** Prefix query parameters */
+/**
+ * Query parameters for listing prefixes.
+ */
 export interface PrefixListParams extends ListParams {
+  /** Filter by exact prefix match */
   prefix?: string;
+  /** Filter by site ID */
   site_id?: number;
+  /** Filter by site slug */
   site?: string;
+  /** Filter by tenant ID */
   tenant_id?: number;
+  /** Filter by tenant slug */
   tenant?: string;
+  /** Filter by role ID */
   role_id?: number;
+  /** Filter by role slug */
   role?: string;
+  /** Filter by status */
   status?: PrefixStatus;
+  /** Filter by tag(s) */
   tag?: string | string[];
+  /** Filter by parent prefix (prefixes within) */
   within?: string;
+  /** Filter by parent prefix (including the parent) */
   within_include?: string;
+  /** Filter by child prefix (prefixes containing) */
   contains?: string;
 }
 
-/** Site query parameters */
+/**
+ * Query parameters for listing sites.
+ */
 export interface SiteListParams extends ListParams {
+  /** Filter by name */
   name?: string;
+  /** Filter by slug */
   slug?: string;
+  /** Filter by region ID */
   region_id?: number;
+  /** Filter by tenant ID */
   tenant_id?: number;
+  /** Filter by tag(s) */
   tag?: string | string[];
 }
 
-/** Tenant query parameters */
+/**
+ * Query parameters for listing tenants.
+ */
 export interface TenantListParams extends ListParams {
+  /** Filter by name */
   name?: string;
+  /** Filter by slug */
   slug?: string;
+  /** Filter by tenant group ID */
   group_id?: number;
+  /** Filter by tag(s) */
   tag?: string | string[];
 }
 
-/** Role query parameters */
+/**
+ * Query parameters for listing roles.
+ */
 export interface RoleListParams extends ListParams {
+  /** Filter by name */
   name?: string;
+  /** Filter by slug */
   slug?: string;
 }
 
-/** Tag query parameters */
+/**
+ * Query parameters for listing tags.
+ */
 export interface TagListParams extends ListParams {
+  /** Filter by name */
   name?: string;
+  /** Filter by slug */
   slug?: string;
 }
-

--- a/packages/netbox/src/export/mapper.ts
+++ b/packages/netbox/src/export/mapper.ts
@@ -1,5 +1,35 @@
 /**
- * Maps Subnetter allocations to NetBox objects
+ * @module export/mapper
+ * @description Maps Subnetter allocations to NetBox objects.
+ *
+ * Provides functions to transform Subnetter's allocation data model into
+ * NetBox's object model. Each function creates a "writable" object suitable
+ * for NetBox's create/update API endpoints.
+ *
+ * ## Mapping Summary
+ *
+ * | Subnetter Concept | NetBox Object | Mapper Function |
+ * |-------------------|---------------|-----------------|
+ * | Account | Tenant | {@link mapAccountToTenant} |
+ * | Cloud Provider | Site Group | {@link mapCloudProviderToSiteGroup} |
+ * | Cloud Region | Site | {@link mapRegionToSite} |
+ * | Availability Zone | Location | {@link mapAzToLocation} |
+ * | Subnet Type | Role | {@link mapSubnetTypeToRole} |
+ * | Allocation | Prefix | {@link mapAllocationToPrefix} |
+ * | Base CIDR | Aggregate | {@link mapBaseCidrToAggregate} |
+ *
+ * ## Extraction Functions
+ *
+ * Helper functions extract unique values from allocations:
+ * - {@link extractAccounts} - Unique account names
+ * - {@link extractCloudProviders} - Unique cloud providers
+ * - {@link extractCloudRegions} - Unique region/provider pairs
+ * - {@link extractAvailabilityZones} - Unique AZ/region/provider tuples
+ * - {@link extractRoles} - Unique subnet types
+ *
+ * @see {@link ./exporter} for the export orchestration
+ *
+ * @packageDocumentation
  */
 
 import type { Allocation } from '@subnetter/core';
@@ -14,14 +44,43 @@ import type {
   PrefixStatus,
 } from '../client/types';
 
-/** Tag used to identify Subnetter-managed objects */
-export const SUBNETTER_MANAGED_TAG = 'subnetter-managed';
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Slugify a string for use in NetBox
+ * Tag name used to identify Subnetter-managed objects in NetBox.
+ *
+ * @remarks
+ * This tag is applied to objects created by Subnetter to distinguish them
+ * from manually-created objects. It can be used for filtering and cleanup.
+ */
+export const SUBNETTER_MANAGED_TAG = 'subnetter-managed';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Utility Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Converts a string to a URL-safe slug for use in NetBox.
+ *
+ * @remarks
+ * Slugs in NetBox must be lowercase alphanumeric with hyphens.
+ * This function:
  * - Converts to lowercase
- * - Replaces spaces and special chars with hyphens
+ * - Replaces spaces and special characters with hyphens
  * - Removes consecutive hyphens
+ * - Trims leading/trailing hyphens
+ *
+ * @param str - Input string to slugify
+ * @returns URL-safe slug
+ *
+ * @example
+ * ```typescript
+ * slugify('AWS Production')  // 'aws-production'
+ * slugify('us-east-1')       // 'us-east-1'
+ * slugify('My App (Dev)')    // 'my-app-dev'
+ * ```
  */
 export function slugify(str: string): string {
   return str
@@ -32,7 +91,45 @@ export function slugify(str: string): string {
 }
 
 /**
- * Extract unique accounts from allocations
+ * Returns the full display name for a cloud provider.
+ *
+ * @param cloudProvider - Provider identifier (aws, azure, gcp)
+ * @returns Full provider name for display
+ *
+ * @example
+ * ```typescript
+ * getCloudProviderFullName('aws')   // 'Amazon Web Services'
+ * getCloudProviderFullName('azure') // 'Microsoft Azure'
+ * getCloudProviderFullName('gcp')   // 'Google Cloud Platform'
+ * getCloudProviderFullName('other') // 'OTHER'
+ * ```
+ *
+ * @internal
+ */
+function getCloudProviderFullName(cloudProvider: string): string {
+  const providerNames: Record<string, string> = {
+    aws: 'Amazon Web Services',
+    azure: 'Microsoft Azure',
+    gcp: 'Google Cloud Platform',
+  };
+  return providerNames[cloudProvider.toLowerCase()] || cloudProvider.toUpperCase();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Extraction Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Extracts unique account names from allocations.
+ *
+ * @param allocations - Array of Subnetter allocations
+ * @returns Array of unique account names
+ *
+ * @example
+ * ```typescript
+ * const accounts = extractAccounts(allocations);
+ * // ['production', 'staging', 'development']
+ * ```
  */
 export function extractAccounts(allocations: Allocation[]): string[] {
   const accounts = new Set<string>();
@@ -43,7 +140,19 @@ export function extractAccounts(allocations: Allocation[]): string[] {
 }
 
 /**
- * Extract unique cloud providers from allocations (for NetBox Site Groups)
+ * Extracts unique cloud providers from allocations.
+ *
+ * @remarks
+ * Cloud providers are mapped to NetBox Site Groups for functional grouping.
+ *
+ * @param allocations - Array of Subnetter allocations
+ * @returns Array of unique cloud provider identifiers
+ *
+ * @example
+ * ```typescript
+ * const providers = extractCloudProviders(allocations);
+ * // ['aws', 'azure', 'gcp']
+ * ```
  */
 export function extractCloudProviders(allocations: Allocation[]): string[] {
   const providers = new Set<string>();
@@ -54,7 +163,23 @@ export function extractCloudProviders(allocations: Allocation[]): string[] {
 }
 
 /**
- * Extract unique cloud regions from allocations (for NetBox Sites)
+ * Extracts unique cloud regions with their providers from allocations.
+ *
+ * @remarks
+ * Cloud regions are mapped to NetBox Sites, grouped under their provider's
+ * Site Group.
+ *
+ * @param allocations - Array of Subnetter allocations
+ * @returns Array of region/provider pairs
+ *
+ * @example
+ * ```typescript
+ * const regions = extractCloudRegions(allocations);
+ * // [
+ * //   { region: 'us-east-1', provider: 'aws' },
+ * //   { region: 'eastus', provider: 'azure' },
+ * // ]
+ * ```
  */
 export function extractCloudRegions(allocations: Allocation[]): Array<{ region: string; provider: string }> {
   const regions = new Map<string, string>();
@@ -71,7 +196,23 @@ export function extractCloudRegions(allocations: Allocation[]): Array<{ region: 
 }
 
 /**
- * Extract unique availability zones from allocations (for NetBox Locations)
+ * Extracts unique availability zones with their region and provider.
+ *
+ * @remarks
+ * Availability zones are mapped to NetBox Locations, which are children
+ * of Sites (regions).
+ *
+ * @param allocations - Array of Subnetter allocations
+ * @returns Array of AZ/region/provider tuples
+ *
+ * @example
+ * ```typescript
+ * const azs = extractAvailabilityZones(allocations);
+ * // [
+ * //   { az: 'us-east-1a', region: 'us-east-1', provider: 'aws' },
+ * //   { az: 'us-east-1b', region: 'us-east-1', provider: 'aws' },
+ * // ]
+ * ```
  */
 export function extractAvailabilityZones(allocations: Allocation[]): Array<{
   az: string;
@@ -96,7 +237,20 @@ export function extractAvailabilityZones(allocations: Allocation[]): Array<{
 }
 
 /**
- * Extract unique subnet types (roles) from allocations
+ * Extracts unique subnet types (roles) from allocations.
+ *
+ * @remarks
+ * Subnet types are mapped to NetBox Roles, which categorize prefixes
+ * by their function (e.g., 'public', 'private', 'database').
+ *
+ * @param allocations - Array of Subnetter allocations
+ * @returns Array of unique subnet type names
+ *
+ * @example
+ * ```typescript
+ * const roles = extractRoles(allocations);
+ * // ['public', 'private', 'database']
+ * ```
  */
 export function extractRoles(allocations: Allocation[]): string[] {
   const roles = new Set<string>();
@@ -106,8 +260,30 @@ export function extractRoles(allocations: Allocation[]): string[] {
   return Array.from(roles);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Mapping Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
- * Map a Subnetter account to a NetBox Tenant
+ * Maps a Subnetter account name to a NetBox Tenant.
+ *
+ * @remarks
+ * Tenants in NetBox represent organizational ownership. Each cloud account
+ * becomes a tenant, allowing prefixes to be associated with their owning
+ * account.
+ *
+ * @param accountName - Cloud account name
+ * @returns Tenant object for NetBox API
+ *
+ * @example
+ * ```typescript
+ * const tenant = mapAccountToTenant('Production AWS');
+ * // {
+ * //   name: 'Production AWS',
+ * //   slug: 'production-aws',
+ * //   description: 'Cloud account managed by Subnetter',
+ * // }
+ * ```
  */
 export function mapAccountToTenant(accountName: string): TenantWritable {
   return {
@@ -118,22 +294,24 @@ export function mapAccountToTenant(accountName: string): TenantWritable {
 }
 
 /**
- * Get the full name for a cloud provider
- */
-function getCloudProviderFullName(cloudProvider: string): string {
-  const providerNames: Record<string, string> = {
-    aws: 'Amazon Web Services',
-    azure: 'Microsoft Azure',
-    gcp: 'Google Cloud Platform',
-  };
-  return providerNames[cloudProvider.toLowerCase()] || cloudProvider.toUpperCase();
-}
-
-/**
- * Map a cloud provider to a NetBox Site Group (functional grouping)
+ * Maps a cloud provider to a NetBox Site Group.
  *
- * Site Groups are used for functional/logical organization, which is
- * appropriate for cloud providers (AWS, Azure, GCP).
+ * @remarks
+ * Site Groups provide functional/logical organization in NetBox. Subnetter
+ * uses them to group cloud regions by provider (AWS, Azure, GCP).
+ *
+ * @param cloudProvider - Cloud provider identifier (aws, azure, gcp)
+ * @returns Site Group object for NetBox API
+ *
+ * @example
+ * ```typescript
+ * const siteGroup = mapCloudProviderToSiteGroup('aws');
+ * // {
+ * //   name: 'Amazon Web Services',
+ * //   slug: 'aws',
+ * //   description: 'Cloud infrastructure provider - Amazon Web Services',
+ * // }
+ * ```
  */
 export function mapCloudProviderToSiteGroup(cloudProvider: string): SiteGroupWritable {
   const fullName = getCloudProviderFullName(cloudProvider);
@@ -146,13 +324,26 @@ export function mapCloudProviderToSiteGroup(cloudProvider: string): SiteGroupWri
 }
 
 /**
- * Map a base CIDR to a NetBox Aggregate
+ * Maps a base CIDR to a NetBox Aggregate.
  *
- * Aggregates represent the root of your IP addressing hierarchy.
- * They are typically RFC 1918 private ranges or public allocations.
+ * @remarks
+ * Aggregates represent the root of the IP addressing hierarchy in NetBox.
+ * Subnetter creates one for the base CIDR to properly anchor the prefix
+ * hierarchy.
  *
- * @param baseCidr - The base CIDR block (e.g., '10.0.0.0/8')
- * @param rirId - The ID of the RIR (e.g., RFC 1918)
+ * @param baseCidr - Base CIDR block (e.g., '10.0.0.0/8')
+ * @param rirId - ID of the RIR (typically RFC 1918 for private ranges)
+ * @returns Aggregate object for NetBox API
+ *
+ * @example
+ * ```typescript
+ * const aggregate = mapBaseCidrToAggregate('10.0.0.0/8', 1);
+ * // {
+ * //   prefix: '10.0.0.0/8',
+ * //   rir: 1,
+ * //   description: 'Root IP allocation for cloud infrastructure',
+ * // }
+ * ```
  */
 export function mapBaseCidrToAggregate(baseCidr: string, rirId: number): AggregateWritable {
   return {
@@ -163,11 +354,28 @@ export function mapBaseCidrToAggregate(baseCidr: string, rirId: number): Aggrega
 }
 
 /**
- * Map a cloud region to a NetBox Site
+ * Maps a cloud region to a NetBox Site.
+ *
+ * @remarks
+ * Sites in NetBox represent physical or logical locations. Cloud regions
+ * are mapped to sites, grouped under their provider's Site Group.
  *
  * @param regionName - Cloud region name (e.g., 'us-east-1')
- * @param cloudProvider - Cloud provider (e.g., 'aws')
- * @param siteGroupId - ID of the parent NetBox Site Group (cloud provider)
+ * @param cloudProvider - Cloud provider identifier
+ * @param siteGroupId - Optional ID of the parent Site Group
+ * @returns Site object for NetBox API
+ *
+ * @example
+ * ```typescript
+ * const site = mapRegionToSite('us-east-1', 'aws', 1);
+ * // {
+ * //   name: 'us-east-1',
+ * //   slug: 'us-east-1',
+ * //   status: 'active',
+ * //   group: 1,
+ * //   description: 'Amazon Web Services region in us-east-1',
+ * // }
+ * ```
  */
 export function mapRegionToSite(
   regionName: string,
@@ -186,12 +394,29 @@ export function mapRegionToSite(
 }
 
 /**
- * Map an availability zone to a NetBox Location
+ * Maps an availability zone to a NetBox Location.
+ *
+ * @remarks
+ * Locations in NetBox represent sub-divisions within sites. Availability
+ * zones are mapped to locations, which are children of their region's Site.
  *
  * @param azName - Availability zone name (e.g., 'us-east-1a')
- * @param regionName - Cloud region name (e.g., 'us-east-1')
- * @param cloudProvider - Cloud provider (e.g., 'aws')
- * @param siteId - ID of the parent NetBox Site (cloud region)
+ * @param regionName - Parent region name
+ * @param cloudProvider - Cloud provider identifier
+ * @param siteId - ID of the parent Site (cloud region)
+ * @returns Location object for NetBox API
+ *
+ * @example
+ * ```typescript
+ * const location = mapAzToLocation('us-east-1a', 'us-east-1', 'aws', 1);
+ * // {
+ * //   name: 'us-east-1a',
+ * //   slug: 'us-east-1a',
+ * //   site: 1,
+ * //   status: 'active',
+ * //   description: 'Amazon Web Services availability zone us-east-1a in us-east-1',
+ * // }
+ * ```
  */
 export function mapAzToLocation(
   azName: string,
@@ -211,7 +436,24 @@ export function mapAzToLocation(
 }
 
 /**
- * Map a subnet type to a NetBox Role
+ * Maps a subnet type to a NetBox Role.
+ *
+ * @remarks
+ * Roles in NetBox categorize prefixes by their function. Each subnet type
+ * in Subnetter (e.g., 'public', 'private') becomes a role.
+ *
+ * @param subnetType - Subnet type name
+ * @returns Role object for NetBox API
+ *
+ * @example
+ * ```typescript
+ * const role = mapSubnetTypeToRole('public');
+ * // {
+ * //   name: 'public',
+ * //   slug: 'public',
+ * //   description: 'Subnet role for public workloads',
+ * // }
+ * ```
  */
 export function mapSubnetTypeToRole(subnetType: string): RoleWritable {
   return {
@@ -221,25 +463,65 @@ export function mapSubnetTypeToRole(subnetType: string): RoleWritable {
   };
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Prefix Mapping
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
- * Options for mapping allocations to prefixes
+ * Options for mapping allocations to prefixes.
  */
 export interface MapPrefixOptions {
-  /** Status to assign to prefixes (default: 'reserved') */
+  /**
+   * Status to assign to the prefix.
+   * @defaultValue 'reserved'
+   */
   status?: PrefixStatus;
-  /** Tenant ID to assign (if known) */
+  /** Tenant ID to assign (maps from account) */
   tenantId?: number;
-  /** Site ID to assign (if known) - used for scope in NetBox 4.x */
+  /** Site ID to assign (maps from region, used for scope in NetBox 4.x) */
   siteId?: number;
-  /** Role ID to assign (if known) */
+  /** Role ID to assign (maps from subnet type) */
   roleId?: number;
 }
 
 /**
- * Map a Subnetter allocation to a NetBox Prefix
+ * Maps a Subnetter allocation to a NetBox Prefix.
  *
- * Note: In NetBox 4.x, the site relationship is handled via scope_type and scope_id
- * instead of the deprecated site field.
+ * @remarks
+ * This is the main mapping function that converts a Subnetter allocation
+ * into a NetBox prefix. It handles:
+ * - CIDR notation
+ * - Status assignment
+ * - Tenant (account) association
+ * - Site scope (NetBox 4.x)
+ * - Role (subnet type) association
+ * - Descriptive text generation
+ *
+ * In NetBox 4.x, the site relationship is handled via `scope_type` and
+ * `scope_id` instead of the deprecated `site` field.
+ *
+ * @param allocation - Subnetter allocation to map
+ * @param options - Optional configuration for the mapping
+ * @returns Prefix object for NetBox API
+ *
+ * @example
+ * ```typescript
+ * const prefix = mapAllocationToPrefix(allocation, {
+ *   status: 'reserved',
+ *   tenantId: 1,
+ *   siteId: 2,
+ *   roleId: 3,
+ * });
+ * // {
+ * //   prefix: '10.1.1.0/24',
+ * //   status: 'reserved',
+ * //   tenant: 1,
+ * //   scope_type: 'dcim.site',
+ * //   scope_id: 2,
+ * //   role: 3,
+ * //   description: 'public subnet in us-east-1a (Amazon Web Services us-east-1)',
+ * // }
+ * ```
  */
 export function mapAllocationToPrefix(
   allocation: Allocation,
@@ -263,8 +545,21 @@ export function mapAllocationToPrefix(
   };
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Key Generation (for diffing)
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
- * Generate a unique key for an allocation (for diffing)
+ * Generates a unique key for an allocation for comparison purposes.
+ *
+ * @param allocation - Subnetter allocation
+ * @returns Unique string key combining all identifying fields
+ *
+ * @example
+ * ```typescript
+ * const key = allocationKey(allocation);
+ * // 'production::aws::us-east-1::us-east-1a::public::10.1.1.0/24'
+ * ```
  */
 export function allocationKey(allocation: Allocation): string {
   return [
@@ -278,9 +573,17 @@ export function allocationKey(allocation: Allocation): string {
 }
 
 /**
- * Generate a unique key for a prefix (for diffing)
+ * Generates a unique key for a prefix for comparison purposes.
+ *
+ * @param prefix - Prefix object with at least a prefix field
+ * @returns The CIDR as the unique key
+ *
+ * @example
+ * ```typescript
+ * const key = prefixKey({ prefix: '10.1.1.0/24' });
+ * // '10.1.1.0/24'
+ * ```
  */
 export function prefixKey(prefix: { prefix: string; description?: string }): string {
   return prefix.prefix;
 }
-

--- a/packages/netbox/src/index.ts
+++ b/packages/netbox/src/index.ts
@@ -1,13 +1,102 @@
 /**
- * @subnetter/netbox - NetBox IPAM integration for Subnetter
+ * @module @subnetter/netbox
+ * @description NetBox IPAM integration for Subnetter.
  *
- * This package provides integration between Subnetter and NetBox,
- * enabling export of Subnetter allocations to NetBox's IPAM system.
+ * This package provides bidirectional integration between Subnetter's CIDR
+ * allocations and NetBox's IP Address Management (IPAM) system. It enables
+ * organizations to maintain a single source of truth for their IP addressing
+ * across multi-cloud environments.
+ *
+ * ## Features
+ *
+ * - **Export to NetBox**: Sync Subnetter allocations to NetBox prefixes
+ * - **Automatic Object Creation**: Creates supporting objects (tenants, sites, roles)
+ * - **Hierarchical Mapping**: Maps cloud concepts to NetBox's data model
+ * - **Dry-Run Mode**: Preview changes before applying them
+ * - **Idempotent Operations**: Safe to run repeatedly without duplicates
+ *
+ * ## NetBox Object Mapping
+ *
+ * Subnetter maps cloud concepts to NetBox objects as follows:
+ *
+ * | Subnetter Concept | NetBox Object | Description |
+ * |-------------------|---------------|-------------|
+ * | Base CIDR | Aggregate | Top-level IP block (e.g., 10.0.0.0/8) |
+ * | Cloud Provider | Site Group | Functional grouping (AWS, Azure, GCP) |
+ * | Cloud Region | Site | Geographic location (us-east-1) |
+ * | Availability Zone | Location | Sub-division within a site |
+ * | Account | Tenant | Ownership/billing boundary |
+ * | Subnet Type | Role | Network function (public, private) |
+ * | Subnet CIDR | Prefix | Actual IP allocation |
+ *
+ * ## Usage
+ *
+ * @example Basic export to NetBox
+ * ```typescript
+ * import { NetBoxClient, NetBoxExporter } from '@subnetter/netbox';
+ * import { CidrAllocator, loadConfig } from '@subnetter/core';
+ *
+ * // Load configuration and generate allocations
+ * const config = await loadConfig('config.json');
+ * const allocator = new CidrAllocator(config);
+ * const allocations = allocator.generateAllocations();
+ *
+ * // Create NetBox client
+ * const client = new NetBoxClient({
+ *   url: 'https://netbox.example.com',
+ *   token: process.env.NETBOX_TOKEN,
+ * });
+ *
+ * // Export to NetBox (dry-run first)
+ * const exporter = new NetBoxExporter(client);
+ * const result = await exporter.export(allocations, {
+ *   dryRun: true,
+ *   baseCidr: config.baseCidr,
+ * });
+ *
+ * console.log(`Would create: ${result.summary.created}`);
+ * console.log(`Would update: ${result.summary.updated}`);
+ * ```
+ *
+ * @example Using the NetBox client directly
+ * ```typescript
+ * import { NetBoxClient } from '@subnetter/netbox';
+ *
+ * const client = new NetBoxClient({
+ *   url: 'https://netbox.example.com',
+ *   token: 'your-api-token',
+ * });
+ *
+ * // List all prefixes
+ * const prefixes = await client.prefixes.listAll();
+ *
+ * // Find a specific prefix
+ * const prefix = await client.prefixes.findByPrefix('10.1.0.0/16');
+ *
+ * // Create a new prefix
+ * await client.prefixes.create({
+ *   prefix: '10.2.0.0/16',
+ *   status: 'reserved',
+ *   description: 'New allocation',
+ * });
+ * ```
+ *
+ * ## API Compatibility
+ *
+ * This package is designed for NetBox 4.x. Key differences from 3.x:
+ * - Prefixes use `scope_type` and `scope_id` instead of `site` field
+ * - API endpoints remain largely the same
+ *
+ * @see {@link https://docs.netbox.dev/en/stable/ | NetBox Documentation}
+ * @see {@link https://github.com/gangster/subnetter | Subnetter Repository}
  *
  * @packageDocumentation
  */
 
-// Client
+// ─────────────────────────────────────────────────────────────────────────────
+// Client Exports
+// ─────────────────────────────────────────────────────────────────────────────
+
 export { NetBoxClient, NetBoxApiError } from './client/NetBoxClient';
 export type {
   NetBoxConfig,
@@ -43,7 +132,10 @@ export type {
   NestedTag,
 } from './client/types';
 
-// Export
+// ─────────────────────────────────────────────────────────────────────────────
+// Export Module
+// ─────────────────────────────────────────────────────────────────────────────
+
 export { NetBoxExporter } from './export/exporter';
 export type {
   ExportOptions,
@@ -67,4 +159,3 @@ export {
   extractAvailabilityZones,
   extractRoles,
 } from './export/mapper';
-


### PR DESCRIPTION
## Summary

Adds comprehensive TSDoc documentation to the NetBox integration package for improved developer experience and API discoverability.

## Changes

### Package Entry Point (`index.ts`)
- Added `@module` and `@packageDocumentation` tags with package overview
- Documented NetBox object mapping in a table format
- Added usage examples for both exporter and direct client usage
- Documented API compatibility notes for NetBox 4.x

### Client Module (`client/NetBoxClient.ts`)
- Added module documentation with endpoint summary table
- Enhanced `NetBoxApiError` class with `@example` and common status codes
- Documented all CRUD operations with `@param`, `@returns`, `@throws`
- Added `@remarks` explaining resource-specific behaviors
- Documented pagination handling in `listAll` methods

### Type Definitions (`client/types.ts`)
- Added module documentation explaining type conventions (Read, Writable, Nested, ListParams)
- Documented all interfaces with property descriptions
- Added `@example` blocks for complex types
- Documented NetBox 4.x changes (`scope_type`/`scope_id` vs deprecated `site`)
- Added `@see` references to related types

### Exporter Module (`export/exporter.ts`)
- Added module documentation with export hierarchy diagram
- Documented all 12 export phases
- Added `@example` blocks for basic and dry-run usage
- Documented `ExportOptions` with `@defaultValue` tags
- Added `@private` tags for internal methods

### Mapper Module (`export/mapper.ts`)
- Added module documentation with mapping summary table
- Documented all extraction functions with usage examples
- Documented all mapping functions with return examples
- Added `@internal` tags for helper functions

## Example Documentation Style

```typescript
/**
 * Maps a Subnetter allocation to a NetBox Prefix.
 *
 * @remarks
 * This is the main mapping function that converts a Subnetter allocation
 * into a NetBox prefix. In NetBox 4.x, the site relationship is handled
 * via `scope_type` and `scope_id` instead of the deprecated `site` field.
 *
 * @param allocation - Subnetter allocation to map
 * @param options - Optional configuration for the mapping
 * @returns Prefix object for NetBox API
 *
 * @example
 * \`\`\`typescript
 * const prefix = mapAllocationToPrefix(allocation, {
 *   status: 'reserved',
 *   tenantId: 1,
 *   siteId: 2,
 * });
 * \`\`\`
 */
```

## Testing
- No functional changes, documentation only
- Linter passes with no errors