### PR TITLE
docs: add netbox and cidr-utils to TypeDoc, improve API links

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -31,7 +31,9 @@ export default defineConfig({
 					label: 'Reference',
 					items: [
 						{ label: 'Configuration', link: '/configuration' },
-						{ label: 'API Documentation', link: '/api/overview' },
+						{ label: 'API Overview', link: '/api/overview' },
+						{ label: 'API Reference', link: '/api/reference' },
+						{ label: 'TypeDoc API Docs', link: '/api/index.html', attrs: { target: '_blank' } },
 						{ label: 'Error Handling', link: '/error-handling' },
 					],
 				},

--- a/packages/docs/src/content/docs/api/overview.mdx
+++ b/packages/docs/src/content/docs/api/overview.mdx
@@ -3,7 +3,20 @@ title: API Overview
 description: "Subnetter provides a programmatic API for hierarchical IPv4 CIDR allocation across multi-cloud infrastructure."
 ---
 
-import { Aside, Tabs, TabItem, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Tabs, TabItem, Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+<CardGrid>
+  <LinkCard
+    title="TypeDoc API Reference"
+    description="Complete auto-generated API documentation with all classes, functions, interfaces, and types."
+    href="/subnetter/api/index.html"
+  />
+  <LinkCard
+    title="API Reference Guide"
+    description="Hand-written reference with examples and usage patterns."
+    href="/subnetter/api/reference/"
+  />
+</CardGrid>
 
 Subnetter provides a programmatic API that allows you to use its functionality in your own Node.js applications. This overview documents the available packages, key components, and usage patterns.
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,7 +3,9 @@
   "entryPointStrategy": "expand",
   "entryPoints": [
     "./packages/core/src/index.ts",
-    "./packages/cli/src/index.ts"
+    "./packages/cli/src/index.ts",
+    "./packages/netbox/src/index.ts",
+    "./packages/cidr-utils/src/index.ts"
   ],
   "out": "docs/api",
   "name": "Subnetter API Documentation",
@@ -15,5 +17,9 @@
   "excludeInternal": true,
   "externalPattern": ["**/node_modules/**"],
   "sort": ["kind", "visibility", "static-first", "alphabetical"],
-  "categorizeByGroup": true
-} 
+  "categorizeByGroup": true,
+  "navigationLinks": {
+    "Documentation": "https://gangster.github.io/subnetter/",
+    "GitHub": "https://github.com/gangster/subnetter"
+  }
+}


### PR DESCRIPTION
## Summary

Improves the TypeDoc configuration and makes the auto-generated API documentation more discoverable.

## Changes

### TypeDoc Configuration (`typedoc.json`)
- **Added `@subnetter/netbox` package** - NetBox integration was missing from API docs
- **Added `@subnetter/cidr-utils` package** - Low-level utilities were missing
- **Added navigation links** - Links back to main docs site and GitHub

```json
"entryPoints": [
  "./packages/core/src/index.ts",
  "./packages/cli/src/index.ts",
  "./packages/netbox/src/index.ts",      // NEW
  "./packages/cidr-utils/src/index.ts"   // NEW
]
```

### API Overview Page
Added prominent LinkCard links at the top of the page:
- **TypeDoc API Reference** - Auto-generated docs with all classes/functions
- **API Reference Guide** - Hand-written reference with examples

### Sidebar Navigation
Updated the Reference section to include separate entries:
- API Overview
- API Reference
- TypeDoc API Docs (opens in new tab)
- Error Handling

## Why This Matters

The TypeDoc documentation is comprehensive and auto-generated from TSDoc comments. Now that we've added comprehensive TSDoc to all packages, this documentation is valuable and should be easy to find.

## Build Integration

The docs build already handles TypeDoc integration:
```bash
# From packages/docs/package.json
"generate-api-docs": "cd ../.. && yarn api-docs && mkdir -p packages/docs/public/api && cp -R docs/api/* packages/docs/public/api/"
```

So the TypeDoc output at `/subnetter/api/index.html` will include all four packages after this change.