### PR TITLE
fix(docs): move TypeDoc to /typedoc/ to avoid Astro route conflict

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -33,7 +33,7 @@ export default defineConfig({
 						{ label: 'Configuration', link: '/configuration' },
 						{ label: 'API Overview', link: '/api/overview' },
 						{ label: 'API Reference', link: '/api/reference' },
-						{ label: 'TypeDoc API Docs', link: '/api/index.html', attrs: { target: '_blank' } },
+						{ label: 'TypeDoc API Docs', link: '/typedoc/index.html', attrs: { target: '_blank' } },
 						{ label: 'Error Handling', link: '/error-handling' },
 					],
 				},

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -16,7 +16,7 @@
     "build": "yarn generate-api-docs && astro build && node postbuild.js",
     "preview": "astro preview",
     "astro": "astro",
-    "generate-api-docs": "cd ../.. && yarn api-docs && mkdir -p packages/docs/public/api && cp -R docs/api/* packages/docs/public/api/",
+    "generate-api-docs": "cd ../.. && yarn api-docs && mkdir -p packages/docs/public/typedoc && cp -R docs/typedoc/* packages/docs/public/typedoc/",
     "build-astro-only": "astro build && node postbuild.js",
     "build-fix": "astro build && node postbuild.js",
     "test": "NODE_ENV=test jest",

--- a/packages/docs/src/content/docs/api/overview.mdx
+++ b/packages/docs/src/content/docs/api/overview.mdx
@@ -9,7 +9,7 @@ import { Aside, Tabs, TabItem, Card, CardGrid, LinkCard } from '@astrojs/starlig
   <LinkCard
     title="TypeDoc API Reference"
     description="Complete auto-generated API documentation with all classes, functions, interfaces, and types."
-    href="/subnetter/api/index.html"
+    href="/subnetter/typedoc/index.html"
   />
   <LinkCard
     title="API Reference Guide"
@@ -532,5 +532,5 @@ main();
 ```
 
 <Aside type="tip">
-  For complete API documentation including all methods and parameters, see the [TypeDoc Generated Documentation](/subnetter/api/index.html).
+  For complete API documentation including all methods and parameters, see the [TypeDoc Generated Documentation](/subnetter/typedoc/index.html).
 </Aside>

--- a/packages/docs/src/content/docs/api/reference.mdx
+++ b/packages/docs/src/content/docs/api/reference.mdx
@@ -6,7 +6,7 @@ description: "Detailed API reference for Subnetter's programmatic interfaces."
 import { Aside, Tabs, TabItem, Card, CardGrid } from '@astrojs/starlight/components';
 
 <Card title="TypeDoc Generated Documentation" icon="document">
-  For the most comprehensive and up-to-date API details, visit the [Generated API Documentation](/subnetter/api/index.html).
+  For the most comprehensive and up-to-date API details, visit the [Generated API Documentation](/subnetter/typedoc/index.html).
 </Card>
 
 This document provides detailed reference information for developers using Subnetter programmatically.

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,7 +7,7 @@
     "./packages/netbox/src/index.ts",
     "./packages/cidr-utils/src/index.ts"
   ],
-  "out": "docs/api",
+  "out": "docs/typedoc",
   "name": "Subnetter API Documentation",
   "includeVersion": true,
   "skipErrorChecking": true,


### PR DESCRIPTION
## Problem

The TypeDoc documentation was inaccessible because of a path conflict:
- TypeDoc was generating to `/api/`
- Astro was also creating routes at `/api/` (from `src/content/docs/api/*.mdx`)
- Astro's routes took precedence, so `/subnetter/api/index.html` showed the Configuration Reference page instead of TypeDoc

As seen at https://gangster.github.io/subnetter/api/index.html - it shows the Starlight page, not TypeDoc.

## Solution

Move TypeDoc to a non-conflicting path: `/typedoc/`

### Changes

| File | Change |
|------|--------|
| `typedoc.json` | Output to `docs/typedoc` instead of `docs/api` |
| `packages/docs/package.json` | Copy to `public/typedoc` instead of `public/api` |
| `packages/docs/astro.config.mjs` | Sidebar link to `/typedoc/index.html` |
| `api/overview.mdx` | Links to `/subnetter/typedoc/index.html` |
| `api/reference.mdx` | Links to `/subnetter/typedoc/index.html` |

## Result

After this change, the TypeDoc documentation will be accessible at:
**https://gangster.github.io/subnetter/typedoc/index.html**

And the API documentation pages in Starlight will continue to work at:
- `/subnetter/api/overview/`
- `/subnetter/api/reference/`