### PR TITLE
fix(docs): use absolute URL for TypeDoc links

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -32,7 +32,7 @@ export default defineConfig({
 					items: [
 						{ label: 'Configuration', link: '/configuration' },
 						{ label: 'API Overview', link: '/api/overview' },
-						{ label: 'TypeDoc API Docs', link: '/typedoc/index.html', attrs: { target: '_blank' } },
+						{ label: 'TypeDoc API Docs', link: 'https://gangster.github.io/subnetter/typedoc/', attrs: { target: '_blank' } },
 						{ label: 'Error Handling', link: '/error-handling' },
 					],
 				},

--- a/packages/docs/src/content/docs/api/overview.mdx
+++ b/packages/docs/src/content/docs/api/overview.mdx
@@ -8,7 +8,7 @@ import { Aside, Tabs, TabItem, Card, CardGrid, LinkCard } from '@astrojs/starlig
 <LinkCard
   title="📚 TypeDoc API Reference"
   description="Complete auto-generated API documentation with all classes, functions, interfaces, and types."
-  href="/subnetter/typedoc/index.html"
+  href="https://gangster.github.io/subnetter/typedoc/"
 />
 
 Subnetter provides a programmatic API that allows you to use its functionality in your own Node.js applications. This overview documents the available packages, key components, and usage patterns.
@@ -525,5 +525,5 @@ main();
 ```
 
 <Aside type="tip">
-  For complete API documentation including all methods and parameters, see the [TypeDoc Generated Documentation](/subnetter/typedoc/index.html).
+  For complete API documentation including all methods and parameters, see the [TypeDoc Generated Documentation](https://gangster.github.io/subnetter/typedoc/).
 </Aside>


### PR DESCRIPTION
## Problem

Clicking 'TypeDoc API Docs' in the sidebar goes to:
`https://gangster.github.io/subnetter/typedoc/index/` (404)

Instead of:
`https://gangster.github.io/subnetter/typedoc/` (works)

## Cause

Astro's `trailingSlash: 'always'` setting transforms `/typedoc/index.html` to `/typedoc/index/`.

## Fix

Use absolute URLs to bypass Astro's URL transformation:
- Sidebar: `https://gangster.github.io/subnetter/typedoc/`
- LinkCard: `https://gangster.github.io/subnetter/typedoc/`
- Markdown link: `https://gangster.github.io/subnetter/typedoc/`