### PR TITLE
feat(nlp): implement LLM provider abstraction layer

### DIFF
--- a/packages/nlp/package.json
+++ b/packages/nlp/package.json
@@ -29,7 +29,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
     "@subnetter/core": "2.2.0",
+    "openai": "^4.77.0",
     "zod": "^3.24.1",
     "zod-to-json-schema": "^3.23.0"
   },

--- a/packages/nlp/src/index.ts
+++ b/packages/nlp/src/index.ts
@@ -7,11 +7,18 @@
  *
  * @example
  * ```typescript
- * import { generateFromNaturalLanguage } from '@subnetter/nlp';
+ * import { createProvider, getConfigJsonSchema } from '@subnetter/nlp';
  *
- * const result = await generateFromNaturalLanguage(
+ * const provider = createProvider({
+ *   provider: 'anthropic',
+ *   model: 'claude-sonnet-4-20250514',
+ *   apiKey: process.env.ANTHROPIC_API_KEY,
+ * });
+ *
+ * const schema = getConfigJsonSchema();
+ * const result = await provider.generateConfig(
  *   'I need subnets for 2 AWS accounts in us-east-1',
- *   { provider: 'anthropic', model: 'claude-sonnet-4-20250514' }
+ *   schema
  * );
  * ```
  *
@@ -21,11 +28,22 @@
 // Schema utilities
 export { getConfigJsonSchema, type JsonSchema } from './schema/converter';
 
-// LLM types and providers (Phase 1)
+// LLM providers and types
+export {
+  createProvider,
+  getDefaultModel,
+  AnthropicProvider,
+  OpenAIProvider,
+  OllamaProvider,
+} from './llm';
+
 export type {
   LLMProvider,
   LLMConfig,
   LLMResponse,
+  LLMError,
   ProviderType,
-} from './llm/types';
+  ConversationContext,
+  ConversationMessage,
+} from './llm';
 

--- a/packages/nlp/src/llm/anthropic.ts
+++ b/packages/nlp/src/llm/anthropic.ts
@@ -1,0 +1,205 @@
+/**
+ * @module llm/anthropic
+ * @description Anthropic Claude LLM provider implementation.
+ *
+ * This module implements the LLM provider interface for Anthropic's Claude models,
+ * using their tool_use feature for structured output.
+ *
+ * @packageDocumentation
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import type {
+  LLMProvider,
+  LLMConfig,
+  LLMResponse,
+  ProviderType,
+  ConversationContext,
+} from './types';
+
+/**
+ * LLM provider implementation for Anthropic Claude.
+ *
+ * @remarks
+ * Uses Anthropic's tool_use feature to generate structured configuration.
+ * The model is instructed to use the `generate_config` tool to produce output.
+ *
+ * @example
+ * ```typescript
+ * const provider = new AnthropicProvider({
+ *   provider: 'anthropic',
+ *   model: 'claude-sonnet-4-20250514',
+ *   apiKey: process.env.ANTHROPIC_API_KEY,
+ * });
+ *
+ * const response = await provider.generateConfig(
+ *   'I need subnets for AWS in us-east-1',
+ *   configJsonSchema
+ * );
+ * ```
+ */
+export class AnthropicProvider implements LLMProvider {
+  private client: Anthropic;
+  private config: LLMConfig;
+
+  /**
+   * Creates a new Anthropic provider.
+   *
+   * @param config - Provider configuration including API key and model
+   */
+  constructor(config: LLMConfig) {
+    this.config = config;
+    this.client = new Anthropic({
+      apiKey: config.apiKey,
+    });
+  }
+
+  /**
+   * Returns the provider type identifier.
+   */
+  getName(): ProviderType {
+    return 'anthropic';
+  }
+
+  /**
+   * Generates a configuration from natural language input.
+   *
+   * @param prompt - User's natural language requirements
+   * @param schema - JSON Schema for the expected output
+   * @returns LLM response with generated config or reasoning
+   */
+  async generateConfig(prompt: string, schema: object): Promise<LLMResponse> {
+    const systemPrompt = `You are a network infrastructure expert helping users plan their cloud network architecture.
+When the user describes their requirements, use the generate_config tool to create a valid Subnetter configuration.
+Be precise with CIDR blocks and follow cloud provider conventions for regions and availability zones.
+If the requirements are unclear, ask clarifying questions instead of guessing.`;
+
+    const response = await this.client.messages.create({
+      model: this.config.model,
+      max_tokens: this.config.maxTokens ?? 4096,
+      temperature: this.config.temperature ?? 0.1,
+      system: systemPrompt,
+      tools: [
+        {
+          name: 'generate_config',
+          description:
+            'Generate a Subnetter configuration for CIDR allocation based on user requirements',
+          input_schema: schema as Anthropic.Tool['input_schema'],
+        },
+      ],
+      messages: [
+        {
+          role: 'user',
+          content: prompt,
+        },
+      ],
+    });
+
+    return this.parseResponse(response);
+  }
+
+  /**
+   * Extracts partial configuration from a clarification response.
+   *
+   * @param prompt - User's response to a clarification question
+   * @param context - Previous conversation context
+   * @returns LLM response with partial config data
+   */
+  async extractPartialConfig(
+    prompt: string,
+    context?: ConversationContext
+  ): Promise<LLMResponse> {
+    const messages: Anthropic.MessageParam[] = [];
+
+    // Add conversation history
+    if (context?.messages) {
+      for (const msg of context.messages) {
+        if (msg.role === 'user' || msg.role === 'assistant') {
+          messages.push({
+            role: msg.role,
+            content: msg.content,
+          });
+        }
+      }
+    }
+
+    // Add current message
+    messages.push({
+      role: 'user',
+      content: prompt,
+    });
+
+    const response = await this.client.messages.create({
+      model: this.config.model,
+      max_tokens: this.config.maxTokens ?? 4096,
+      temperature: this.config.temperature ?? 0.1,
+      system: `Extract the network configuration information from the user's response.
+Focus on: accounts, regions, cloud providers, subnet types, and CIDR preferences.
+Use the generate_config tool to output any configuration you can extract.`,
+      tools: [
+        {
+          name: 'generate_config',
+          description: 'Extract configuration from user response',
+          input_schema: {
+            type: 'object',
+            properties: {
+              baseCidr: { type: 'string' },
+              accounts: { type: 'array' },
+              subnetTypes: { type: 'object' },
+              cloudProviders: { type: 'array' },
+            },
+          },
+        },
+      ],
+      messages,
+    });
+
+    return this.parseResponse(response);
+  }
+
+  /**
+   * Checks if the provider is available and configured.
+   *
+   * @returns True if API key is set and valid
+   */
+  async isAvailable(): Promise<boolean> {
+    return !!this.config.apiKey;
+  }
+
+  /**
+   * Parses the Anthropic API response into our standard format.
+   *
+   * @param response - Raw Anthropic API response
+   * @returns Normalized LLM response
+   */
+  private parseResponse(response: Anthropic.Message): LLMResponse {
+    const tokensUsed =
+      (response.usage?.input_tokens ?? 0) + (response.usage?.output_tokens ?? 0);
+
+    // Look for tool_use content
+    const toolUse = response.content.find(
+      (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use'
+    );
+
+    if (toolUse) {
+      return {
+        config: toolUse.input,
+        tokensUsed,
+        rawResponse: response,
+      };
+    }
+
+    // If no tool use, return text as reasoning
+    const textBlock = response.content.find(
+      (block): block is Anthropic.TextBlock => block.type === 'text'
+    );
+
+    return {
+      config: null,
+      reasoning: textBlock?.text,
+      tokensUsed,
+      rawResponse: response,
+    };
+  }
+}
+

--- a/packages/nlp/src/llm/factory.ts
+++ b/packages/nlp/src/llm/factory.ts
@@ -1,0 +1,140 @@
+/**
+ * @module llm/factory
+ * @description Factory for creating LLM provider instances.
+ *
+ * This module provides a factory function to create the appropriate LLM provider
+ * based on configuration, handling API keys and default settings.
+ *
+ * @example
+ * ```typescript
+ * import { createProvider } from '@subnetter/nlp';
+ *
+ * const provider = createProvider({
+ *   provider: 'anthropic',
+ *   model: 'claude-sonnet-4-20250514',
+ *   apiKey: process.env.ANTHROPIC_API_KEY,
+ * });
+ *
+ * const response = await provider.generateConfig('Create subnets...', schema);
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import type { LLMConfig, LLMProvider, ProviderType } from './types';
+import { AnthropicProvider } from './anthropic';
+import { OpenAIProvider } from './openai';
+import { OllamaProvider } from './ollama';
+
+/**
+ * Default models for each provider.
+ */
+const DEFAULT_MODELS: Record<ProviderType, string> = {
+  anthropic: 'claude-sonnet-4-20250514',
+  openai: 'gpt-4o',
+  ollama: 'llama3.1',
+};
+
+/**
+ * Default Ollama base URL.
+ */
+const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
+
+/**
+ * Gets the default model for a given provider.
+ *
+ * @param provider - The provider type
+ * @returns The default model name for that provider
+ */
+export function getDefaultModel(provider: ProviderType): string {
+  return DEFAULT_MODELS[provider];
+}
+
+/**
+ * Creates an LLM provider instance based on configuration.
+ *
+ * @param config - Configuration specifying the provider and settings
+ * @returns An LLM provider instance ready to use
+ * @throws Error if the provider type is unknown
+ *
+ * @remarks
+ * API keys are resolved in the following order:
+ * 1. Explicit `apiKey` in config
+ * 2. Environment variable (ANTHROPIC_API_KEY, OPENAI_API_KEY)
+ * 3. None (throws for providers requiring a key)
+ *
+ * @example
+ * ```typescript
+ * // Using explicit API key
+ * const provider = createProvider({
+ *   provider: 'anthropic',
+ *   model: 'claude-sonnet-4-20250514',
+ *   apiKey: 'sk-ant-...',
+ * });
+ *
+ * // Using environment variable
+ * const provider = createProvider({
+ *   provider: 'openai',
+ *   model: 'gpt-4o',
+ *   // Uses OPENAI_API_KEY from environment
+ * });
+ *
+ * // Local Ollama (no key needed)
+ * const provider = createProvider({
+ *   provider: 'ollama',
+ *   model: 'llama3.1',
+ * });
+ * ```
+ */
+export function createProvider(config: LLMConfig): LLMProvider {
+  const resolvedConfig = resolveConfig(config);
+
+  switch (resolvedConfig.provider) {
+    case 'anthropic':
+      return new AnthropicProvider(resolvedConfig);
+    case 'openai':
+      return new OpenAIProvider(resolvedConfig);
+    case 'ollama':
+      return new OllamaProvider(resolvedConfig);
+    default:
+      throw new Error(`Unknown provider: ${config.provider}`);
+  }
+}
+
+/**
+ * Resolves configuration with defaults and environment variables.
+ *
+ * @param config - User-provided configuration
+ * @returns Fully resolved configuration
+ */
+function resolveConfig(config: LLMConfig): LLMConfig {
+  const resolved: LLMConfig = {
+    ...config,
+    model: config.model || DEFAULT_MODELS[config.provider],
+    temperature: config.temperature ?? 0.1,
+    maxTokens: config.maxTokens ?? 4096,
+  };
+
+  // Resolve API keys from environment
+  if (!resolved.apiKey) {
+    switch (config.provider) {
+      case 'anthropic':
+        resolved.apiKey = process.env.ANTHROPIC_API_KEY;
+        break;
+      case 'openai':
+        resolved.apiKey = process.env.OPENAI_API_KEY;
+        break;
+      case 'ollama':
+        // Ollama doesn't need an API key
+        break;
+    }
+  }
+
+  // Resolve Ollama base URL
+  if (config.provider === 'ollama' && !resolved.baseUrl) {
+    resolved.baseUrl = process.env.OLLAMA_BASE_URL || DEFAULT_OLLAMA_URL;
+  }
+
+  return resolved;
+}
+

--- a/packages/nlp/src/llm/index.ts
+++ b/packages/nlp/src/llm/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @module llm
+ * @description LLM provider abstraction layer.
+ *
+ * This module exports the factory function and all provider implementations
+ * for creating LLM providers that can generate Subnetter configurations.
+ *
+ * @packageDocumentation
+ */
+
+// Types
+export type {
+  LLMProvider,
+  LLMConfig,
+  LLMResponse,
+  LLMError,
+  ProviderType,
+  ConversationContext,
+  ConversationMessage,
+} from './types';
+
+// Factory
+export { createProvider, getDefaultModel } from './factory';
+
+// Provider implementations
+export { AnthropicProvider } from './anthropic';
+export { OpenAIProvider } from './openai';
+export { OllamaProvider } from './ollama';
+

--- a/packages/nlp/src/llm/ollama.ts
+++ b/packages/nlp/src/llm/ollama.ts
@@ -1,0 +1,222 @@
+/**
+ * @module llm/ollama
+ * @description Ollama local LLM provider implementation.
+ *
+ * This module implements the LLM provider interface for Ollama,
+ * enabling local model usage without API keys or costs.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  LLMProvider,
+  LLMConfig,
+  LLMResponse,
+  ProviderType,
+  ConversationContext,
+} from './types';
+
+/**
+ * Default Ollama API endpoint.
+ */
+const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
+
+/**
+ * LLM provider implementation for Ollama (local models).
+ *
+ * @remarks
+ * Ollama runs locally and doesn't require an API key.
+ * This provider uses the chat API with structured prompting
+ * to generate JSON output.
+ *
+ * @example
+ * ```typescript
+ * const provider = new OllamaProvider({
+ *   provider: 'ollama',
+ *   model: 'llama3.1',
+ *   baseUrl: 'http://localhost:11434', // optional
+ * });
+ *
+ * const response = await provider.generateConfig(
+ *   'I need subnets for GCP in us-central1',
+ *   configJsonSchema
+ * );
+ * ```
+ */
+export class OllamaProvider implements LLMProvider {
+  private config: LLMConfig;
+  private baseUrl: string;
+
+  /**
+   * Creates a new Ollama provider.
+   *
+   * @param config - Provider configuration including model and base URL
+   */
+  constructor(config: LLMConfig) {
+    this.config = config;
+    this.baseUrl = config.baseUrl || DEFAULT_OLLAMA_URL;
+  }
+
+  /**
+   * Returns the provider type identifier.
+   */
+  getName(): ProviderType {
+    return 'ollama';
+  }
+
+  /**
+   * Generates a configuration from natural language input.
+   *
+   * @param prompt - User's natural language requirements
+   * @param schema - JSON Schema for the expected output (used for prompting)
+   * @returns LLM response with generated config or reasoning
+   */
+  async generateConfig(prompt: string, schema: object): Promise<LLMResponse> {
+    const systemPrompt = `You are a network infrastructure expert helping users plan their cloud network architecture.
+Generate a valid Subnetter configuration based on the user's requirements.
+
+IMPORTANT: Your response must be ONLY valid JSON matching this schema:
+${JSON.stringify(schema, null, 2)}
+
+Do not include any explanation or markdown. Return only the JSON object.
+Be precise with CIDR blocks and follow cloud provider conventions for regions.`;
+
+    const response = await this.chat(systemPrompt, prompt);
+    return this.parseResponse(response);
+  }
+
+  /**
+   * Extracts partial configuration from a clarification response.
+   *
+   * @param prompt - User's response to a clarification question
+   * @param context - Previous conversation context
+   * @returns LLM response with partial config data
+   */
+  async extractPartialConfig(
+    prompt: string,
+    context?: ConversationContext
+  ): Promise<LLMResponse> {
+    let fullPrompt = '';
+
+    // Include conversation history
+    if (context?.messages) {
+      for (const msg of context.messages) {
+        fullPrompt += `${msg.role}: ${msg.content}\n`;
+      }
+    }
+
+    fullPrompt += `user: ${prompt}`;
+
+    const systemPrompt = `Extract network configuration information from the conversation.
+Focus on: accounts, regions, cloud providers, subnet types, and CIDR preferences.
+
+Return ONLY a JSON object with any configuration you can extract:
+{
+  "baseCidr": "string or null",
+  "accounts": "array or null",
+  "subnetTypes": "object or null",
+  "cloudProviders": "array or null"
+}
+
+Do not include null fields. Return only the JSON object.`;
+
+    const response = await this.chat(systemPrompt, fullPrompt);
+    return this.parseResponse(response);
+  }
+
+  /**
+   * Checks if Ollama is available and running.
+   *
+   * @returns True if Ollama is reachable
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/version`);
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Sends a chat request to the Ollama API.
+   *
+   * @param systemPrompt - System instructions
+   * @param userPrompt - User message
+   * @returns Raw API response
+   */
+  private async chat(
+    systemPrompt: string,
+    userPrompt: string
+  ): Promise<OllamaResponse> {
+    const response = await fetch(`${this.baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: this.config.model,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+        stream: false,
+        options: {
+          temperature: this.config.temperature ?? 0.1,
+          num_predict: this.config.maxTokens ?? 4096,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Ollama API error: ${response.statusText}`);
+    }
+
+    return response.json() as Promise<OllamaResponse>;
+  }
+
+  /**
+   * Parses the Ollama API response into our standard format.
+   *
+   * @param response - Raw Ollama API response
+   * @returns Normalized LLM response
+   */
+  private parseResponse(response: OllamaResponse): LLMResponse {
+    const content = response.message?.content || '';
+
+    // Try to parse as JSON
+    try {
+      // Handle potential markdown code blocks
+      const jsonMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
+      const jsonStr = jsonMatch ? jsonMatch[1].trim() : content.trim();
+
+      const config = JSON.parse(jsonStr);
+      return {
+        config,
+        rawResponse: response,
+      };
+    } catch {
+      // Not valid JSON, return as reasoning
+      return {
+        config: null,
+        reasoning: content,
+        rawResponse: response,
+      };
+    }
+  }
+}
+
+/**
+ * Ollama API response type.
+ */
+interface OllamaResponse {
+  message?: {
+    role: string;
+    content: string;
+  };
+  done?: boolean;
+  total_duration?: number;
+  prompt_eval_count?: number;
+  eval_count?: number;
+}
+

--- a/packages/nlp/src/llm/openai.ts
+++ b/packages/nlp/src/llm/openai.ts
@@ -1,0 +1,228 @@
+/**
+ * @module llm/openai
+ * @description OpenAI GPT LLM provider implementation.
+ *
+ * This module implements the LLM provider interface for OpenAI's GPT models,
+ * using their function calling feature for structured output.
+ *
+ * @packageDocumentation
+ */
+
+import OpenAI from 'openai';
+import type {
+  LLMProvider,
+  LLMConfig,
+  LLMResponse,
+  ProviderType,
+  ConversationContext,
+} from './types';
+
+/**
+ * LLM provider implementation for OpenAI GPT.
+ *
+ * @remarks
+ * Uses OpenAI's function calling feature to generate structured configuration.
+ * The model is instructed to use the `generate_config` function to produce output.
+ *
+ * @example
+ * ```typescript
+ * const provider = new OpenAIProvider({
+ *   provider: 'openai',
+ *   model: 'gpt-4o',
+ *   apiKey: process.env.OPENAI_API_KEY,
+ * });
+ *
+ * const response = await provider.generateConfig(
+ *   'I need subnets for Azure in eastus',
+ *   configJsonSchema
+ * );
+ * ```
+ */
+export class OpenAIProvider implements LLMProvider {
+  private client: OpenAI;
+  private config: LLMConfig;
+
+  /**
+   * Creates a new OpenAI provider.
+   *
+   * @param config - Provider configuration including API key and model
+   */
+  constructor(config: LLMConfig) {
+    this.config = config;
+    this.client = new OpenAI({
+      apiKey: config.apiKey,
+    });
+  }
+
+  /**
+   * Returns the provider type identifier.
+   */
+  getName(): ProviderType {
+    return 'openai';
+  }
+
+  /**
+   * Generates a configuration from natural language input.
+   *
+   * @param prompt - User's natural language requirements
+   * @param schema - JSON Schema for the expected output
+   * @returns LLM response with generated config or reasoning
+   */
+  async generateConfig(prompt: string, schema: object): Promise<LLMResponse> {
+    const systemPrompt = `You are a network infrastructure expert helping users plan their cloud network architecture.
+When the user describes their requirements, use the generate_config function to create a valid Subnetter configuration.
+Be precise with CIDR blocks and follow cloud provider conventions for regions and availability zones.
+If the requirements are unclear, ask clarifying questions instead of guessing.`;
+
+    const response = await this.client.chat.completions.create({
+      model: this.config.model,
+      max_tokens: this.config.maxTokens ?? 4096,
+      temperature: this.config.temperature ?? 0.1,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: prompt },
+      ],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'generate_config',
+            description:
+              'Generate a Subnetter configuration for CIDR allocation based on user requirements',
+            parameters: schema as OpenAI.FunctionParameters,
+          },
+        },
+      ],
+      tool_choice: 'auto',
+    });
+
+    return this.parseResponse(response);
+  }
+
+  /**
+   * Extracts partial configuration from a clarification response.
+   *
+   * @param prompt - User's response to a clarification question
+   * @param context - Previous conversation context
+   * @returns LLM response with partial config data
+   */
+  async extractPartialConfig(
+    prompt: string,
+    context?: ConversationContext
+  ): Promise<LLMResponse> {
+    const messages: OpenAI.ChatCompletionMessageParam[] = [
+      {
+        role: 'system',
+        content: `Extract the network configuration information from the user's response.
+Focus on: accounts, regions, cloud providers, subnet types, and CIDR preferences.
+Use the generate_config function to output any configuration you can extract.`,
+      },
+    ];
+
+    // Add conversation history
+    if (context?.messages) {
+      for (const msg of context.messages) {
+        if (msg.role === 'user' || msg.role === 'assistant') {
+          messages.push({
+            role: msg.role,
+            content: msg.content,
+          });
+        }
+      }
+    }
+
+    // Add current message
+    messages.push({
+      role: 'user',
+      content: prompt,
+    });
+
+    const response = await this.client.chat.completions.create({
+      model: this.config.model,
+      max_tokens: this.config.maxTokens ?? 4096,
+      temperature: this.config.temperature ?? 0.1,
+      messages,
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'generate_config',
+            description: 'Extract configuration from user response',
+            parameters: {
+              type: 'object',
+              properties: {
+                baseCidr: { type: 'string' },
+                accounts: { type: 'array' },
+                subnetTypes: { type: 'object' },
+                cloudProviders: { type: 'array' },
+              },
+            } as OpenAI.FunctionParameters,
+          },
+        },
+      ],
+    });
+
+    return this.parseResponse(response);
+  }
+
+  /**
+   * Checks if the provider is available and configured.
+   *
+   * @returns True if API key is set
+   */
+  async isAvailable(): Promise<boolean> {
+    return !!this.config.apiKey;
+  }
+
+  /**
+   * Parses the OpenAI API response into our standard format.
+   *
+   * @param response - Raw OpenAI API response
+   * @returns Normalized LLM response
+   */
+  private parseResponse(
+    response: OpenAI.ChatCompletion
+  ): LLMResponse {
+    const tokensUsed = response.usage?.total_tokens ?? 0;
+    const choice = response.choices[0];
+
+    if (!choice) {
+      return {
+        config: null,
+        reasoning: 'No response from model',
+        tokensUsed,
+        rawResponse: response,
+      };
+    }
+
+    // Check for tool calls
+    const toolCall = choice.message.tool_calls?.[0];
+
+    if (toolCall && toolCall.type === 'function') {
+      try {
+        const config = JSON.parse(toolCall.function.arguments);
+        return {
+          config,
+          tokensUsed,
+          rawResponse: response,
+        };
+      } catch {
+        return {
+          config: null,
+          reasoning: 'Failed to parse function arguments',
+          tokensUsed,
+          rawResponse: response,
+        };
+      }
+    }
+
+    // Return text content as reasoning
+    return {
+      config: null,
+      reasoning: choice.message.content ?? undefined,
+      tokensUsed,
+      rawResponse: response,
+    };
+  }
+}
+

--- a/packages/nlp/tests/llm/factory.test.ts
+++ b/packages/nlp/tests/llm/factory.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the LLM provider factory.
+ *
+ * @module tests/llm/factory
+ */
+
+import { createProvider, getDefaultModel } from '../../src/llm/factory';
+import type { LLMConfig, ProviderType } from '../../src/llm/types';
+
+describe('LLM Provider Factory', () => {
+  describe('createProvider', () => {
+    it('creates an Anthropic provider when provider is "anthropic"', () => {
+      const config: LLMConfig = {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-20250514',
+        apiKey: 'test-key',
+      };
+
+      const provider = createProvider(config);
+
+      expect(provider).toBeDefined();
+      expect(provider.getName()).toBe('anthropic');
+    });
+
+    it('creates an OpenAI provider when provider is "openai"', () => {
+      const config: LLMConfig = {
+        provider: 'openai',
+        model: 'gpt-4o',
+        apiKey: 'test-key',
+      };
+
+      const provider = createProvider(config);
+
+      expect(provider).toBeDefined();
+      expect(provider.getName()).toBe('openai');
+    });
+
+    it('creates an Ollama provider when provider is "ollama"', () => {
+      const config: LLMConfig = {
+        provider: 'ollama',
+        model: 'llama3.1',
+        baseUrl: 'http://localhost:11434',
+      };
+
+      const provider = createProvider(config);
+
+      expect(provider).toBeDefined();
+      expect(provider.getName()).toBe('ollama');
+    });
+
+    it('throws an error for unknown provider type', () => {
+      const config = {
+        provider: 'unknown' as ProviderType,
+        model: 'test',
+      };
+
+      expect(() => createProvider(config)).toThrow('Unknown provider: unknown');
+    });
+
+    it('uses ANTHROPIC_API_KEY env var when apiKey not provided', () => {
+      const originalEnv = process.env.ANTHROPIC_API_KEY;
+      process.env.ANTHROPIC_API_KEY = 'env-key';
+
+      const config: LLMConfig = {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-20250514',
+      };
+
+      const provider = createProvider(config);
+      expect(provider).toBeDefined();
+
+      process.env.ANTHROPIC_API_KEY = originalEnv;
+    });
+
+    it('uses OPENAI_API_KEY env var when apiKey not provided', () => {
+      const originalEnv = process.env.OPENAI_API_KEY;
+      process.env.OPENAI_API_KEY = 'env-key';
+
+      const config: LLMConfig = {
+        provider: 'openai',
+        model: 'gpt-4o',
+      };
+
+      const provider = createProvider(config);
+      expect(provider).toBeDefined();
+
+      process.env.OPENAI_API_KEY = originalEnv;
+    });
+
+    it('uses default Ollama URL when baseUrl not provided', () => {
+      const config: LLMConfig = {
+        provider: 'ollama',
+        model: 'llama3.1',
+      };
+
+      const provider = createProvider(config);
+      expect(provider).toBeDefined();
+    });
+  });
+
+  describe('getDefaultModel', () => {
+    it('returns claude-sonnet-4-20250514 for anthropic', () => {
+      expect(getDefaultModel('anthropic')).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('returns gpt-4o for openai', () => {
+      expect(getDefaultModel('openai')).toBe('gpt-4o');
+    });
+
+    it('returns llama3.1 for ollama', () => {
+      expect(getDefaultModel('ollama')).toBe('llama3.1');
+    });
+  });
+});
+

--- a/packages/nlp/tests/llm/providers.test.ts
+++ b/packages/nlp/tests/llm/providers.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Tests for LLM provider implementations.
+ *
+ * @module tests/llm/providers
+ */
+
+import type { LLMConfig } from '../../src/llm/types';
+
+// Create mock functions
+const mockAnthropicCreate = jest.fn();
+const mockOpenAICreate = jest.fn();
+
+// Mock the external SDKs before importing providers
+jest.mock('@anthropic-ai/sdk', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    messages: {
+      create: mockAnthropicCreate,
+    },
+  })),
+}));
+
+jest.mock('openai', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: mockOpenAICreate,
+      },
+    },
+  })),
+}));
+
+// Mock fetch for Ollama
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Import after mocks are set up
+import { AnthropicProvider } from '../../src/llm/anthropic';
+import { OpenAIProvider } from '../../src/llm/openai';
+import { OllamaProvider } from '../../src/llm/ollama';
+
+describe('AnthropicProvider', () => {
+  let provider: AnthropicProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const config: LLMConfig = {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-20250514',
+      apiKey: 'test-key',
+    };
+    provider = new AnthropicProvider(config);
+  });
+
+  describe('getName', () => {
+    it('returns "anthropic"', () => {
+      expect(provider.getName()).toBe('anthropic');
+    });
+  });
+
+  describe('generateConfig', () => {
+    it('formats tool_use request correctly', async () => {
+      mockAnthropicCreate.mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'generate_config',
+            input: {
+              baseCidr: '10.0.0.0/8',
+              accounts: [{ name: 'prod', clouds: { aws: { regions: ['us-east-1'] } } }],
+              subnetTypes: { public: 26, private: 24 },
+            },
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+
+      const schema = { type: 'object', properties: {} };
+      const response = await provider.generateConfig('Create subnets', schema);
+
+      expect(mockAnthropicCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-sonnet-4-20250514',
+          tools: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'generate_config',
+            }),
+          ]),
+        })
+      );
+
+      expect(response.config).toEqual({
+        baseCidr: '10.0.0.0/8',
+        accounts: [{ name: 'prod', clouds: { aws: { regions: ['us-east-1'] } } }],
+        subnetTypes: { public: 26, private: 24 },
+      });
+    });
+
+    it('parses tool response into config object', async () => {
+      const expectedConfig = {
+        baseCidr: '10.0.0.0/8',
+        accounts: [{ name: 'test', clouds: { aws: { regions: ['us-west-2'] } } }],
+        subnetTypes: { public: 24 },
+      };
+
+      mockAnthropicCreate.mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'generate_config',
+            input: expectedConfig,
+          },
+        ],
+        usage: { input_tokens: 50, output_tokens: 100 },
+      });
+
+      const response = await provider.generateConfig('test', {});
+
+      expect(response.config).toEqual(expectedConfig);
+      expect(response.tokensUsed).toBe(150);
+    });
+
+    it('handles API errors gracefully', async () => {
+      mockAnthropicCreate.mockRejectedValueOnce(new Error('API rate limit exceeded'));
+
+      await expect(provider.generateConfig('test', {})).rejects.toThrow(
+        'API rate limit exceeded'
+      );
+    });
+
+    it('handles response without tool_use', async () => {
+      mockAnthropicCreate.mockResolvedValueOnce({
+        content: [
+          {
+            type: 'text',
+            text: 'I cannot generate that configuration.',
+          },
+        ],
+        usage: { input_tokens: 50, output_tokens: 20 },
+      });
+
+      const response = await provider.generateConfig('test', {});
+
+      expect(response.config).toBeNull();
+      expect(response.reasoning).toBe('I cannot generate that configuration.');
+    });
+  });
+
+  describe('isAvailable', () => {
+    it('returns true when API key is configured', async () => {
+      const available = await provider.isAvailable();
+      expect(available).toBe(true);
+    });
+  });
+});
+
+describe('OpenAIProvider', () => {
+  let provider: OpenAIProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const config: LLMConfig = {
+      provider: 'openai',
+      model: 'gpt-4o',
+      apiKey: 'test-key',
+    };
+    provider = new OpenAIProvider(config);
+  });
+
+  describe('getName', () => {
+    it('returns "openai"', () => {
+      expect(provider.getName()).toBe('openai');
+    });
+  });
+
+  describe('generateConfig', () => {
+    it('formats function_call request correctly', async () => {
+      mockOpenAICreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  type: 'function',
+                  function: {
+                    name: 'generate_config',
+                    arguments: JSON.stringify({
+                      baseCidr: '10.0.0.0/8',
+                      accounts: [{ name: 'prod', clouds: { aws: { regions: ['us-east-1'] } } }],
+                      subnetTypes: { public: 26 },
+                    }),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage: { total_tokens: 200 },
+      });
+
+      const schema = { type: 'object', properties: {} };
+      await provider.generateConfig('Create subnets', schema);
+
+      expect(mockOpenAICreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-4o',
+          tools: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'function',
+              function: expect.objectContaining({
+                name: 'generate_config',
+              }),
+            }),
+          ]),
+        })
+      );
+    });
+
+    it('parses function response into config object', async () => {
+      const expectedConfig = {
+        baseCidr: '172.16.0.0/12',
+        accounts: [{ name: 'staging', clouds: { azure: { regions: ['eastus'] } } }],
+        subnetTypes: { private: 24 },
+      };
+
+      mockOpenAICreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  type: 'function',
+                  function: {
+                    name: 'generate_config',
+                    arguments: JSON.stringify(expectedConfig),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage: { total_tokens: 150 },
+      });
+
+      const response = await provider.generateConfig('test', {});
+
+      expect(response.config).toEqual(expectedConfig);
+      expect(response.tokensUsed).toBe(150);
+    });
+
+    it('handles API errors gracefully', async () => {
+      mockOpenAICreate.mockRejectedValueOnce(new Error('Invalid API key'));
+
+      await expect(provider.generateConfig('test', {})).rejects.toThrow('Invalid API key');
+    });
+
+    it('handles response without function call', async () => {
+      mockOpenAICreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: 'I need more information.',
+            },
+          },
+        ],
+        usage: { total_tokens: 50 },
+      });
+
+      const response = await provider.generateConfig('test', {});
+
+      expect(response.config).toBeNull();
+      expect(response.reasoning).toBe('I need more information.');
+    });
+  });
+});
+
+describe('OllamaProvider', () => {
+  let provider: OllamaProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const config: LLMConfig = {
+      provider: 'ollama',
+      model: 'llama3.1',
+      baseUrl: 'http://localhost:11434',
+    };
+    provider = new OllamaProvider(config);
+  });
+
+  describe('getName', () => {
+    it('returns "ollama"', () => {
+      expect(provider.getName()).toBe('ollama');
+    });
+  });
+
+  describe('generateConfig', () => {
+    it('sends request to Ollama API', async () => {
+      const expectedConfig = {
+        baseCidr: '10.0.0.0/8',
+        accounts: [{ name: 'local', clouds: { aws: { regions: ['us-east-1'] } } }],
+        subnetTypes: { public: 24 },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            message: {
+              content: JSON.stringify(expectedConfig),
+            },
+          }),
+      });
+
+      const response = await provider.generateConfig('test', {});
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:11434/api/chat',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      expect(response.config).toEqual(expectedConfig);
+    });
+
+    it('handles connection errors gracefully', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Connection refused'));
+
+      await expect(provider.generateConfig('test', {})).rejects.toThrow('Connection refused');
+    });
+
+    it('handles non-JSON response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            message: {
+              content: 'This is not JSON',
+            },
+          }),
+      });
+
+      const response = await provider.generateConfig('test', {});
+
+      expect(response.config).toBeNull();
+      expect(response.reasoning).toBe('This is not JSON');
+    });
+  });
+
+  describe('isAvailable', () => {
+    it('returns true when Ollama is running', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ version: '0.1.0' }),
+      });
+
+      const available = await provider.isAvailable();
+
+      expect(available).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:11434/api/version');
+    });
+
+    it('returns false when Ollama is not running', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Connection refused'));
+
+      const available = await provider.isAvailable();
+
+      expect(available).toBe(false);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@anthropic-ai/sdk@npm:^0.39.0":
+  version: 0.39.0
+  resolution: "@anthropic-ai/sdk@npm:0.39.0"
+  dependencies:
+    "@types/node": "npm:^18.11.18"
+    "@types/node-fetch": "npm:^2.6.4"
+    abort-controller: "npm:^3.0.0"
+    agentkeepalive: "npm:^4.2.1"
+    form-data-encoder: "npm:1.7.2"
+    formdata-node: "npm:^4.3.2"
+    node-fetch: "npm:^2.6.7"
+  checksum: 10/8f1cb2d6a797ed095503ceec4271347ba9ee101c020fe3f5080c6853a5f3a9fc874649fcd0e3ae584c33e58548368cf3fb1da167221172859a1dff1e8c3419f6
+  languageName: node
+  linkType: hard
+
 "@astrojs/compiler@npm:^2.11.0":
   version: 2.11.0
   resolution: "@astrojs/compiler@npm:2.11.0"
@@ -4504,9 +4519,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@subnetter/nlp@workspace:packages/nlp"
   dependencies:
+    "@anthropic-ai/sdk": "npm:^0.39.0"
     "@subnetter/core": "npm:2.1.0"
     "@types/node": "npm:^22.10.2"
     jest: "npm:^29.7.0"
+    openai: "npm:^4.77.0"
     ts-jest: "npm:^29.2.5"
     typescript: "npm:^5.7.2"
     zod: "npm:^3.24.1"
@@ -4797,6 +4814,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-fetch@npm:^2.6.4":
+  version: 2.6.13
+  resolution: "@types/node-fetch@npm:2.6.13"
+  dependencies:
+    "@types/node": "npm:*"
+    form-data: "npm:^4.0.4"
+  checksum: 10/944d52214791ebba482ca1393a4f0d62b0dbac5f7343ff42c128b75d5356d8bcefd4df77771b55c1acd19d118e16e9bd5d2792819c51bc13402d1c87c0975435
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*, @types/node@npm:^22.13.10":
   version: 22.13.10
   resolution: "@types/node@npm:22.13.10"
@@ -4810,6 +4837,15 @@ __metadata:
   version: 17.0.45
   resolution: "@types/node@npm:17.0.45"
   checksum: 10/b45fff7270b5e81be19ef91a66b764a8b21473a97a8d211218a52e3426b79ad48f371819ab9153370756b33ba284e5c875463de4d2cf48a472e9098d7f09e8a2
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.11.18":
+  version: 18.19.130
+  resolution: "@types/node@npm:18.19.130"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10/ebb85c6edcec78df926de27d828ecbeb1b3d77c165ceef95bfc26e171edbc1924245db4eb2d7d6230206fe6b1a1f7665714fe1c70739e9f5980d8ce31af6ef82
   languageName: node
   linkType: hard
 
@@ -5287,6 +5323,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "abort-controller@npm:3.0.0"
+  dependencies:
+    event-target-shim: "npm:^5.0.0"
+  checksum: 10/ed84af329f1828327798229578b4fe03a4dd2596ba304083ebd2252666bdc1d7647d66d0b18704477e1f8aa315f055944aa6e859afebd341f12d0a53c37b4b40
+  languageName: node
+  linkType: hard
+
 "acorn-jsx@npm:^5.0.0, acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -5318,6 +5363,15 @@ __metadata:
   version: 7.1.3
   resolution: "agent-base@npm:7.1.3"
   checksum: 10/3db6d8d4651f2aa1a9e4af35b96ab11a7607af57a24f3bc721a387eaa3b5f674e901f0a648b0caefd48f3fd117c7761b79a3b55854e2aebaa96c3f32cf76af84
+  languageName: node
+  linkType: hard
+
+"agentkeepalive@npm:^4.2.1":
+  version: 4.6.0
+  resolution: "agentkeepalive@npm:4.6.0"
+  dependencies:
+    humanize-ms: "npm:^1.2.1"
+  checksum: 10/80c546bd88dd183376d6a29e5598f117f380b1d567feb1de184241d6ece721e2bdd38f179a1674276de01780ccae229a38c60a77317e2f5ad2f1818856445bd7
   languageName: node
   linkType: hard
 
@@ -8187,6 +8241,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"event-target-shim@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "event-target-shim@npm:5.0.1"
+  checksum: 10/49ff46c3a7facbad3decb31f597063e761785d7fdb3920d4989d7b08c97a61c2f51183e2f3a03130c9088df88d4b489b1b79ab632219901f184f85158508f4c8
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^5.0.1":
   version: 5.0.1
   resolution: "eventemitter3@npm:5.0.1"
@@ -8600,6 +8661,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data-encoder@npm:1.7.2":
+  version: 1.7.2
+  resolution: "form-data-encoder@npm:1.7.2"
+  checksum: 10/227bf2cea083284411fd67472ccc22f5cb354ca92c00690e11ff5ed942d993c13ac99dea365046306200f8bd71e1a7858d2d99e236de694b806b1f374a4ee341
+  languageName: node
+  linkType: hard
+
 "form-data@npm:^4.0.0":
   version: 4.0.2
   resolution: "form-data@npm:4.0.2"
@@ -8622,6 +8690,16 @@ __metadata:
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
   checksum: 10/52ecd6e927c8c4e215e68a7ad5e0f7c1031397439672fd9741654b4a94722c4182e74cc815b225dcb5be3f4180f36428f67c6dd39eaa98af0dcfdd26c00c19cd
+  languageName: node
+  linkType: hard
+
+"formdata-node@npm:^4.3.2":
+  version: 4.4.1
+  resolution: "formdata-node@npm:4.4.1"
+  dependencies:
+    node-domexception: "npm:1.0.0"
+    web-streams-polyfill: "npm:4.0.0-beta.3"
+  checksum: 10/29622f75533107c1bbcbe31fda683e6a55859af7f48ec354a9800591ce7947ed84cd3ef2b2fcb812047a884f17a1bac75ce098ffc17e23402cd373e49c1cd335
   languageName: node
   linkType: hard
 
@@ -9588,6 +9666,15 @@ __metadata:
   version: 8.0.0
   resolution: "human-signals@npm:8.0.0"
   checksum: 10/89acdc7081ac2a065e41cca7351c4b0fe2382e213b7372f90df6a554e340f31b49388a307adc1d6f4c60b2b4fe81eeff0bc1f44be6f5d844311cd92ccc7831c6
+  languageName: node
+  linkType: hard
+
+"humanize-ms@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "humanize-ms@npm:1.2.1"
+  dependencies:
+    ms: "npm:^2.0.0"
+  checksum: 10/9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
   languageName: node
   linkType: hard
 
@@ -12754,7 +12841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.1.2, ms@npm:^2.1.3":
+"ms@npm:^2.0.0, ms@npm:^2.1.2, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10/aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -12918,6 +13005,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-domexception@npm:1.0.0":
+  version: 1.0.0
+  resolution: "node-domexception@npm:1.0.0"
+  checksum: 10/e332522f242348c511640c25a6fc7da4f30e09e580c70c6b13cb0be83c78c3e71c8d4665af2527e869fc96848924a4316ae7ec9014c091e2156f41739d4fa233
+  languageName: node
+  linkType: hard
+
 "node-emoji@npm:^2.2.0":
   version: 2.2.0
   resolution: "node-emoji@npm:2.2.0"
@@ -12934,6 +13028,20 @@ __metadata:
   version: 1.6.6
   resolution: "node-fetch-native@npm:1.6.6"
   checksum: 10/e90d5287fdfb10b9b13276158c9c0ff4318eef222562cf4a504e71665236dea9dda10ae77eb9f0f89cb7677a32ccf2326b9b54f7090121c2af2ac617c1256f8f
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.7":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10/b24f8a3dc937f388192e59bcf9d0857d7b6940a2496f328381641cb616efccc9866e89ec43f2ec956bbd6c3d3ee05524ce77fe7b29ccd34692b3a16f237d6676
   languageName: node
   linkType: hard
 
@@ -13349,6 +13457,31 @@ __metadata:
     regex: "npm:^5.1.1"
     regex-recursion: "npm:^5.1.1"
   checksum: 10/7ac89fe04791650c21a146e58c985de394597e0ab3eb7d7c46699d09f87d6aca63d9f2470f1473c5adfa16961c360df6858e6a24b2429ebd7c73620ca68aec98
+  languageName: node
+  linkType: hard
+
+"openai@npm:^4.77.0":
+  version: 4.104.0
+  resolution: "openai@npm:4.104.0"
+  dependencies:
+    "@types/node": "npm:^18.11.18"
+    "@types/node-fetch": "npm:^2.6.4"
+    abort-controller: "npm:^3.0.0"
+    agentkeepalive: "npm:^4.2.1"
+    form-data-encoder: "npm:1.7.2"
+    formdata-node: "npm:^4.3.2"
+    node-fetch: "npm:^2.6.7"
+  peerDependencies:
+    ws: ^8.18.0
+    zod: ^3.23.8
+  peerDependenciesMeta:
+    ws:
+      optional: true
+    zod:
+      optional: true
+  bin:
+    openai: bin/cli
+  checksum: 10/e1bdfea7b58f6d6cc0c2787254e9ae0395c7cb78b6ad4383c2777fd929ff43d2cb614c12ff7aaef04e260a6b48f3bc15f3c864abb9df35cfc7594e6aa46d4858
   languageName: node
   linkType: hard
 
@@ -16100,6 +16233,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 10/8f1f5aa6cb232f9e1bdc86f485f916b7aa38caee8a778b378ffec0b70d9307873f253f5cbadbe2955ece2ac5c83d0dc14a77513166ccd0a0c7fe197e21396695
+  languageName: node
+  linkType: hard
+
 "traverse@npm:0.6.8":
   version: 0.6.8
   resolution: "traverse@npm:0.6.8"
@@ -17162,10 +17302,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web-streams-polyfill@npm:4.0.0-beta.3":
+  version: 4.0.0-beta.3
+  resolution: "web-streams-polyfill@npm:4.0.0-beta.3"
+  checksum: 10/dcdef67de57d83008f9dc330662b65ba4497315555dd0e4e7bcacb132ffdf8a830eaab8f74ad40a4a44f542461f51223f406e2a446ece1cc29927859b1405853
+  languageName: node
+  linkType: hard
+
 "web-worker@npm:^1.2.0":
   version: 1.5.0
   resolution: "web-worker@npm:1.5.0"
   checksum: 10/1209461e2c731fe8e8297c95a8a324c6dd00fd9f3c489ed79d18a15592731324762b7b06c8b6bc404596259aa13cd413119e0153e12a80f47a7f374960461e0d
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 10/b65b9f8d6854572a84a5c69615152b63371395f0c5dcd6729c45789052296df54314db2bc3e977df41705eacb8bc79c247cee139a63fa695192f95816ed528ad
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10/f95adbc1e80820828b45cc671d97da7cd5e4ef9deb426c31bcd5ab00dc7103042291613b3ef3caec0a2335ed09e0d5ed026c940755dbb6d404e2b27f940fdf07
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Implements the LLM provider abstraction layer for Phase 1 of the NLP interface.

## Changes

### LLM Provider Factory (`src/llm/factory.ts`)
- `createProvider(config)`: Creates appropriate provider based on config
- `getDefaultModel(provider)`: Returns default model for each provider
- Resolves API keys from environment variables
- Default Ollama URL handling

### Provider Implementations

#### AnthropicProvider (`src/llm/anthropic.ts`)
- Uses Claude's `tool_use` feature for structured output
- Default model: `claude-sonnet-4-20250514`
- Supports conversation context for clarification

#### OpenAIProvider (`src/llm/openai.ts`)
- Uses GPT's function calling feature
- Default model: `gpt-4o`
- Parses JSON from function arguments

#### OllamaProvider (`src/llm/ollama.ts`)
- Uses local Ollama instance (no API key needed)
- Default model: `llama3.1`
- Falls back gracefully when unavailable

### Tests
- 27 new tests covering:
  - Provider factory creation
  - Environment variable resolution
  - Tool/function call formatting
  - Response parsing
  - Error handling
  - Availability checks

## Phase 1 Progress

- [x] Package scaffolding
- [x] Schema converter
- [x] LLM provider abstraction
- [ ] Config generation pipeline
- [ ] CLI chat command

## Dependencies Added
- `@anthropic-ai/sdk`: ^0.39.0
- `openai`: ^4.77.0